### PR TITLE
Add bahasa Indonesia language

### DIFF
--- a/packages/admin/dashboard/src/i18n/languages.ts
+++ b/packages/admin/dashboard/src/i18n/languages.ts
@@ -27,6 +27,7 @@ import {
   nl,
   hu,
   bs,
+  id,
 } from "date-fns/locale"
 import { Language } from "./types"
 
@@ -186,6 +187,12 @@ export const languages: Language[] = [
     display_name: "Tiếng Việt",
     ltr: true,
     date_locale: vi,
+  },
+  {
+    code: "id",
+    display_name: "Bahasa Indonesia",
+    ltr: true,
+    date_locale: id,
   },
   {
     code: "ko",

--- a/packages/admin/dashboard/src/i18n/translations/id.json
+++ b/packages/admin/dashboard/src/i18n/translations/id.json
@@ -1,0 +1,3020 @@
+{
+    "$schema": "./$schema.json",
+    "general": {
+        "ascending": "Menaik",
+        "descending": "Menurun",
+        "add": "Tambah",
+        "start": "Mulai",
+        "end": "Akhir",
+        "open": "Buka",
+        "close": "Tutup",
+        "apply": "Terapkan",
+        "range": "Rentang",
+        "search": "Cari",
+        "of": "dari",
+        "results": "hasil",
+        "pages": "halaman",
+        "next": "Berikutnya",
+        "prev": "Sebelumnya",
+        "is": "adalah",
+        "timeline": "Linimasa",
+        "success": "Berhasil",
+        "warning": "Peringatan",
+        "tip": "Tips",
+        "error": "Kesalahan",
+        "select": "Pilih",
+        "selected": "Dipilih",
+        "enabled": "Diaktifkan",
+        "disabled": "Dinonaktifkan",
+        "expired": "Kedaluwarsa",
+        "active": "Aktif",
+        "revoked": "Dicabut",
+        "new": "Baru",
+        "modified": "Dimodifikasi",
+        "added": "Ditambahkan",
+        "removed": "Dihapus",
+        "admin": "Admin",
+        "store": "Toko",
+        "details": "Detail",
+        "items_one": "{{count}} item",
+        "items_other": "{{count}} item",
+        "countSelected": "{{count}} dipilih",
+        "countOfTotalSelected": "{{count}} dari {{total}} dipilih",
+        "plusCount": "+ {{count}}",
+        "plusCountMore": "+ {{count}} lagi",
+        "areYouSure": "Anda yakin?",
+        "areYouSureDescription": "Anda akan menghapus {{entity}} {{title}}. Tindakan ini tidak dapat dibatalkan.",
+        "noRecordsFound": "Tidak ada catatan ditemukan",
+        "typeToConfirm": "Ketik {val} untuk konfirmasi:",
+        "noResultsTitle": "Tidak ada hasil",
+        "noResultsMessage": "Coba ubah filter atau kueri pencarian",
+        "noSearchResults": "Tidak ada hasil pencarian",
+        "noSearchResultsFor": "Tidak ada hasil pencarian untuk <0>'{{query}}'</0>",
+        "noRecordsTitle": "Tidak ada catatan",
+        "noRecordsMessage": "Tidak ada catatan untuk ditampilkan",
+        "unsavedChangesTitle": "Anda yakin ingin meninggalkan formulir ini?",
+        "unsavedChangesDescription": "Anda memiliki perubahan yang belum disimpan yang akan hilang jika Anda keluar dari formulir ini.",
+        "includesTaxTooltip": "Harga di kolom ini sudah termasuk pajak.",
+        "excludesTaxTooltip": "Harga di kolom ini belum termasuk pajak.",
+        "noMoreData": "Tidak ada data lagi"
+    },
+    "json": {
+        "header": "JSON",
+        "numberOfKeys_one": "{{count}} kunci",
+        "numberOfKeys_other": "{{count}} kunci",
+        "drawer": {
+            "header_one": "JSON <0>· {{count}} kunci</0>",
+            "header_other": "JSON <0>· {{count}} kunci</0>",
+            "description": "Lihat data JSON untuk objek ini."
+        }
+    },
+    "metadata": {
+        "header": "Metadata",
+        "numberOfKeys_one": "{{count}} kunci",
+        "numberOfKeys_other": "{{count}} kunci",
+        "edit": {
+            "header": "Edit Metadata",
+            "description": "Edit metadata untuk objek ini.",
+            "successToast": "Metadata berhasil diperbarui.",
+            "actions": {
+                "insertRowAbove": "Sisipkan baris di atas",
+                "insertRowBelow": "Sisipkan baris di bawah",
+                "deleteRow": "Hapus baris"
+            },
+            "labels": {
+                "key": "Kunci",
+                "value": "Nilai"
+            },
+            "complexRow": {
+                "label": "Beberapa baris dinonaktifkan",
+                "description": "Objek ini berisi metadata non-primitif, seperti array atau objek, yang tidak dapat diedit di sini. Untuk mengedit baris yang dinonaktifkan, gunakan API secara langsung.",
+                "tooltip": "Baris ini dinonaktifkan karena berisi data non-primitif."
+            }
+        }
+    },
+    "validation": {
+        "mustBeInt": "Nilai harus berupa bilangan bulat.",
+        "mustBePositive": "Nilai harus berupa bilangan positif."
+    },
+    "actions": {
+        "save": "Simpan",
+        "saveAsDraft": "Simpan sebagai draf",
+        "copy": "Salin",
+        "copied": "Tersalin",
+        "duplicate": "Duplikat",
+        "publish": "Publikasikan",
+        "create": "Buat",
+        "delete": "Hapus",
+        "remove": "Hapus",
+        "revoke": "Cabut",
+        "cancel": "Batal",
+        "forceConfirm": "Paksa konfirmasi",
+        "continueEdit": "Lanjutkan edit",
+        "enable": "Aktifkan",
+        "disable": "Nonaktifkan",
+        "undo": "Urungkan",
+        "complete": "Selesai",
+        "viewDetails": "Lihat detail",
+        "back": "Kembali",
+        "close": "Tutup",
+        "showMore": "Tampilkan lebih banyak",
+        "continue": "Lanjutkan",
+        "continueWithEmail": "Lanjutkan dengan Email",
+        "idCopiedToClipboard": "ID tersalin ke papan klip",
+        "addReason": "Tambah Alasan",
+        "addNote": "Tambah Catatan",
+        "reset": "Atur ulang",
+        "confirm": "Konfirmasi",
+        "edit": "Edit",
+        "addItems": "Tambah item",
+        "download": "Unduh",
+        "clear": "Bersihkan",
+        "clearAll": "Bersihkan semua",
+        "apply": "Terapkan",
+        "add": "Tambah",
+        "select": "Pilih",
+        "browse": "Jelajahi",
+        "logout": "Keluar",
+        "hide": "Sembunyikan",
+        "export": "Ekspor",
+        "import": "Impor",
+        "cannotUndo": "Tindakan ini tidak dapat dibatalkan"
+    },
+    "operators": {
+        "in": "Dalam"
+    },
+    "app": {
+        "search": {
+            "label": "Cari",
+            "title": "Cari",
+            "description": "Cari seluruh toko Anda, termasuk pesanan, produk, pelanggan, dan lainnya.",
+            "allAreas": "Semua area",
+            "navigation": "Navigasi",
+            "openResult": "Buka hasil",
+            "showMore": "Tampilkan lebih banyak",
+            "placeholder": "Lompat ke atau temukan apa saja...",
+            "noResultsTitle": "Tidak ada hasil ditemukan",
+            "noResultsMessage": "Coba ubah filter atau kueri pencarian",
+            "emptySearchTitle": "Ketik untuk mencari",
+            "emptySearchMessage": "Masukkan kata kunci atau frasa untuk menjelajahi.",
+            "loadMore": "Muat {{count}} lagi",
+            "groups": {
+                "all": "Semua area",
+                "customer": "Pelanggan",
+                "customerGroup": "Grup Pelanggan",
+                "product": "Produk",
+                "productVariant": "Varian Produk",
+                "inventory": "Inventaris",
+                "reservation": "Reservasi",
+                "category": "Kategori",
+                "collection": "Koleksi",
+                "order": "Pesanan",
+                "promotion": "Promosi",
+                "campaign": "Kampanye",
+                "priceList": "Daftar Harga",
+                "user": "Pengguna",
+                "region": "Wilayah",
+                "taxRegion": "Wilayah Pajak",
+                "returnReason": "Alasan Pengembalian",
+                "salesChannel": "Saluran Penjualan",
+                "productType": "Jenis Produk",
+                "productTag": "Tag Produk",
+                "location": "Lokasi",
+                "shippingProfile": "Profil Pengiriman",
+                "publishableApiKey": "Kunci API yang Dapat Dipublikasikan",
+                "secretApiKey": "Kunci API Rahasia",
+                "command": "Perintah",
+                "navigation": "Navigasi"
+            }
+        },
+        "keyboardShortcuts": {
+            "pageShortcut": "Lompat ke",
+            "settingShortcut": "Pengaturan",
+            "commandShortcut": "Perintah",
+            "then": "lalu",
+            "navigation": {
+                "goToOrders": "Pesanan",
+                "goToProducts": "Produk",
+                "goToCollections": "Koleksi",
+                "goToCategories": "Kategori",
+                "goToCustomers": "Pelanggan",
+                "goToCustomerGroups": "Grup Pelanggan",
+                "goToInventory": "Inventaris",
+                "goToReservations": "Reservasi",
+                "goToPriceLists": "Daftar Harga",
+                "goToPromotions": "Promosi",
+                "goToCampaigns": "Kampanye"
+            },
+            "settings": {
+                "goToSettings": "Pengaturan",
+                "goToStore": "Toko",
+                "goToUsers": "Pengguna",
+                "goToRegions": "Wilayah",
+                "goToTaxRegions": "Wilayah Pajak",
+                "goToSalesChannels": "Saluran Penjualan",
+                "goToProductTypes": "Jenis Produk",
+                "goToLocations": "Lokasi",
+                "goToPublishableApiKeys": "Kunci API yang Dapat Dipublikasikan",
+                "goToSecretApiKeys": "Kunci API Rahasia",
+                "goToWorkflows": "Alur Kerja",
+                "goToProfile": "Profil",
+                "goToReturnReasons": "Alasan pengembalian"
+            }
+        },
+        "menus": {
+            "user": {
+                "documentation": "Dokumentasi",
+                "changelog": "Catatan Perubahan",
+                "shortcuts": "Pintasan",
+                "profileSettings": "Pengaturan profil",
+                "theme": {
+                    "label": "Tema",
+                    "dark": "Gelap",
+                    "light": "Terang",
+                    "system": "Sistem"
+                }
+            },
+            "store": {
+                "label": "Toko",
+                "storeSettings": "Pengaturan toko"
+            },
+            "actions": {
+                "logout": "Keluar"
+            }
+        },
+        "nav": {
+            "accessibility": {
+                "title": "Navigasi",
+                "description": "Menu navigasi untuk dasbor."
+            },
+            "common": {
+                "extensions": "Ekstensi"
+            },
+            "main": {
+                "store": "Toko",
+                "storeSettings": "Pengaturan toko"
+            },
+            "settings": {
+                "header": "Pengaturan",
+                "general": "Umum",
+                "developer": "Pengembang",
+                "myAccount": "Akun Saya"
+            }
+        }
+    },
+    "dataGrid": {
+        "columns": {
+            "view": "Lihat",
+            "resetToDefault": "Atur ulang ke default",
+            "disabled": "Mengubah kolom yang terlihat dinonaktifkan."
+        },
+        "shortcuts": {
+            "label": "Pintasan",
+            "commands": {
+                "undo": "Urungkan",
+                "redo": "Ulangi",
+                "copy": "Salin",
+                "paste": "Tempel",
+                "edit": "Edit",
+                "delete": "Hapus",
+                "clear": "Bersihkan",
+                "moveUp": "Pindahkan ke atas",
+                "moveDown": "Pindahkan ke bawah",
+                "moveLeft": "Pindahkan ke kiri",
+                "moveRight": "Pindahkan ke kanan",
+                "moveTop": "Pindahkan ke atas",
+                "moveBottom": "Pindahkan ke bawah",
+                "selectDown": "Pilih ke bawah",
+                "selectUp": "Pilih ke atas",
+                "selectColumnDown": "Pilih kolom ke bawah",
+                "selectColumnUp": "Pilih kolom ke atas",
+                "focusToolbar": "Fokus bilah alat",
+                "focusCancel": "Fokus batal"
+            }
+        },
+        "errors": {
+            "fixError": "Perbaiki kesalahan",
+            "count_one": "{{count}} kesalahan",
+            "count_other": "{{count}} kesalahan"
+        }
+    },
+    "filters": {
+        "sortLabel": "Urutkan",
+        "filterLabel": "Filter",
+        "searchLabel": "Cari",
+        "date": {
+            "today": "Hari ini",
+            "lastSevenDays": "7 hari terakhir",
+            "lastThirtyDays": "30 hari terakhir",
+            "lastNinetyDays": "90 hari terakhir",
+            "lastTwelveMonths": "12 bulan terakhir",
+            "custom": "Kustom",
+            "from": "Dari",
+            "to": "Sampai",
+            "starting": "Mulai",
+            "ending": "Berakhir"
+        },
+        "compare": {
+            "lessThan": "Kurang dari",
+            "greaterThan": "Lebih dari",
+            "exact": "Persis",
+            "range": "Rentang",
+            "lessThanLabel": "kurang dari {{value}}",
+            "greaterThanLabel": "lebih dari {{value}}",
+            "andLabel": "dan"
+        },
+        "sorting": {
+            "alphabeticallyAsc": "A ke Z",
+            "alphabeticallyDesc": "Z ke A",
+            "dateAsc": "Terbaru dulu",
+            "dateDesc": "Terlama dulu"
+        },
+        "radio": {
+            "yes": "Ya",
+            "no": "Tidak",
+            "true": "Benar",
+            "false": "Salah"
+        },
+        "addFilter": "Tambah filter"
+    },
+    "errorBoundary": {
+        "badRequestTitle": "400 - Permintaan buruk",
+        "badRequestMessage": "Permintaan tidak dapat dipahami oleh server karena sintaks yang salah bentuk.",
+        "notFoundTitle": "404 - Tidak ada halaman di alamat ini",
+        "notFoundMessage": "Periksa URL dan coba lagi, atau gunakan bilah pencarian untuk menemukan apa yang Anda cari.",
+        "internalServerErrorTitle": "500 - Kesalahan server internal",
+        "internalServerErrorMessage": "Terjadi kesalahan tak terduga di server. Silakan coba lagi nanti.",
+        "defaultTitle": "Terjadi kesalahan",
+        "defaultMessage": "Terjadi kesalahan tak terduga saat merender halaman ini.",
+        "noMatchMessage": "Halaman yang Anda cari tidak ada.",
+        "backToDashboard": "Kembali ke dasbor"
+    },
+    "addresses": {
+        "title": "Alamat",
+        "shippingAddress": {
+            "header": "Alamat Pengiriman",
+            "editHeader": "Edit Alamat Pengiriman",
+            "editLabel": "Alamat pengiriman",
+            "label": "Alamat pengiriman"
+        },
+        "billingAddress": {
+            "header": "Alamat Penagihan",
+            "editHeader": "Edit Alamat Penagihan",
+            "editLabel": "Alamat penagihan",
+            "label": "Alamat penagihan",
+            "sameAsShipping": "Sama dengan alamat pengiriman"
+        },
+        "contactHeading": "Kontak",
+        "locationHeading": "Lokasi"
+    },
+    "email": {
+        "editHeader": "Edit Email",
+        "editLabel": "Email",
+        "label": "Email"
+    },
+    "transferOwnership": {
+        "header": "Transfer Kepemilikan",
+        "label": "Transfer kepemilikan",
+        "details": {
+            "order": "Detail pesanan",
+            "draft": "Detail draf"
+        },
+        "currentOwner": {
+            "label": "Pemilik saat ini",
+            "hint": "Pemilik pesanan saat ini."
+        },
+        "newOwner": {
+            "label": "Pemilik baru",
+            "hint": "Pemilik baru untuk mentransfer pesanan."
+        },
+        "validation": {
+            "mustBeDifferent": "Pemilik baru harus berbeda dari pemilik saat ini.",
+            "required": "Pemilik baru wajib diisi."
+        }
+    },
+    "sales_channels": {
+        "availableIn": "Tersedia di <0>{{x}}</0> dari <1>{{y}}</1> saluran penjualan"
+    },
+    "products": {
+        "domain": "Produk",
+        "list": {
+            "noRecordsMessage": "Buat produk pertama Anda untuk mulai berjualan."
+        },
+        "edit": {
+            "header": "Edit Produk",
+            "description": "Edit detail produk.",
+            "successToast": "Produk {{title}} berhasil diperbarui."
+        },
+        "create": {
+            "title": "Buat Produk",
+            "description": "Buat produk baru.",
+            "header": "Umum",
+            "tabs": {
+                "details": "Detail",
+                "organize": "Atur",
+                "variants": "Varian",
+                "inventory": "Kit inventaris"
+            },
+            "errors": {
+                "variants": "Pilih setidaknya satu varian.",
+                "options": "Buat setidaknya satu opsi.",
+                "uniqueSku": "SKU harus unik."
+            },
+            "inventory": {
+                "heading": "Kit inventaris",
+                "label": "Tambah item inventaris ke kit inventaris varian.",
+                "itemPlaceholder": "Pilih item inventaris",
+                "quantityPlaceholder": "Berapa banyak dari ini yang dibutuhkan untuk kit?"
+            },
+            "variants": {
+                "header": "Varian",
+                "subHeadingTitle": "Ya, ini adalah produk dengan varian",
+                "subHeadingDescription": "Jika tidak dicentang, kami akan membuat varian default untuk Anda",
+                "optionTitle": {
+                    "placeholder": "Ukuran"
+                },
+                "optionValues": {
+                    "placeholder": "Kecil, Sedang, Besar"
+                },
+                "productVariants": {
+                    "label": "Varian produk",
+                    "hint": "Peringkat ini akan memengaruhi urutan varian di etalase Anda.",
+                    "alert": "Tambah opsi untuk membuat varian.",
+                    "tip": "Varian yang tidak dicentang tidak akan dibuat. Anda selalu dapat membuat dan mengedit varian setelahnya, tetapi daftar ini sesuai dengan variasi dalam opsi produk Anda."
+                },
+                "productOptions": {
+                    "label": "Opsi produk",
+                    "hint": "Definisikan opsi untuk produk, misal: warna, ukuran, dll."
+                }
+            },
+            "successToast": "Produk {{title}} berhasil dibuat."
+        },
+        "export": {
+            "header": "Ekspor Daftar Produk",
+            "description": "Ekspor daftar produk ke file CSV.",
+            "success": {
+                "title": "Kami sedang memproses ekspor Anda",
+                "description": "Mengekspor data mungkin memakan waktu beberapa menit. Kami akan memberitahu Anda setelah selesai."
+            },
+            "filters": {
+                "title": "Filter",
+                "description": "Terapkan filter di tabel ikhtisar untuk menyesuaikan tampilan ini"
+            },
+            "columns": {
+                "title": "Kolom",
+                "description": "Sesuaikan data yang diekspor untuk memenuhi kebutuhan spesifik"
+            }
+        },
+        "import": {
+            "header": "Impor Daftar Produk",
+            "uploadLabel": "Impor Produk",
+            "uploadHint": "Seret dan lepas file CSV di sini atau klik untuk mengunggah",
+            "description": "Impor produk dengan menyediakan file CSV dalam format yang telah ditentukan",
+            "template": {
+                "title": "Tidak yakin cara mengatur daftar Anda?",
+                "description": "Unduh template di bawah untuk memastikan Anda mengikuti format yang benar."
+            },
+            "upload": {
+                "title": "Unggah file CSV",
+                "description": "Melalui impor Anda dapat menambah atau memperbarui produk. Untuk memperbarui produk yang sudah ada, Anda harus menggunakan handle dan ID yang sudah ada, untuk memperbarui varian yang sudah ada, Anda harus menggunakan ID yang sudah ada. Anda akan diminta konfirmasi sebelum kami mengimpor produk.",
+                "preprocessing": "Memproses awal...",
+                "productsToCreate": "Produk akan dibuat",
+                "productsToUpdate": "Produk akan diperbarui"
+            },
+            "success": {
+                "title": "Kami sedang memproses impor Anda",
+                "description": "Mengimpor data mungkin memakan waktu cukup lama. Kami akan memberitahu Anda setelah selesai."
+            }
+        },
+        "deleteWarning": "Anda akan menghapus produk {{title}}. Tindakan ini tidak dapat dibatalkan.",
+        "variants": {
+            "header": "Varian",
+            "empty": {
+                "heading": "Tidak ada varian",
+                "description": "Tidak ada varian untuk ditampilkan."
+            },
+            "filtered": {
+                "heading": "Tidak ada hasil",
+                "description": "Tidak ada varian yang cocok dengan kriteria filter saat ini."
+            }
+        },
+        "attributes": "Atribut",
+        "editAttributes": "Edit Atribut",
+        "editOptions": "Edit Opsi",
+        "editPrices": "Edit harga",
+        "media": {
+            "label": "Media",
+            "editHint": "Tambah media ke produk untuk menampilkannya di etalase Anda.",
+            "makeThumbnail": "Jadikan thumbnail",
+            "uploadImagesLabel": "Unggah gambar",
+            "uploadImagesHint": "Seret dan lepas gambar di sini atau klik untuk mengunggah.",
+            "invalidFileType": "'{{name}}' bukan jenis file yang didukung. Jenis file yang didukung adalah: {{types}}.",
+            "failedToUpload": "Gagal mengunggah media yang ditambahkan. Silakan coba lagi.",
+            "deleteWarning_one": "Anda akan menghapus {{count}} gambar. Tindakan ini tidak dapat dibatalkan.",
+            "deleteWarning_other": "Anda akan menghapus {{count}} gambar. Tindakan ini tidak dapat dibatalkan.",
+            "deleteWarningWithThumbnail_one": "Anda akan menghapus {{count}} gambar termasuk thumbnail. Tindakan ini tidak dapat dibatalkan.",
+            "deleteWarningWithThumbnail_other": "Anda akan menghapus {{count}} gambar termasuk thumbnail. Tindakan ini tidak dapat dibatalkan.",
+            "thumbnailTooltip": "Thumbnail",
+            "galleryLabel": "Galeri",
+            "downloadImageLabel": "Unduh gambar saat ini",
+            "deleteImageLabel": "Hapus gambar saat ini",
+            "emptyState": {
+                "header": "Belum ada media",
+                "description": "Tambah media ke produk untuk menampilkannya di etalase Anda.",
+                "action": "Tambah media"
+            },
+            "successToast": "Media berhasil diperbarui."
+        },
+        "discountableHint": "Jika tidak dicentang, diskon tidak akan diterapkan pada produk ini.",
+        "noSalesChannels": "Tidak tersedia di saluran penjualan mana pun",
+        "variantCount_one": "{{count}} varian",
+        "variantCount_other": "{{count}} varian",
+        "deleteVariantWarning": "Anda akan menghapus varian {{title}}. Tindakan ini tidak dapat dibatalkan.",
+        "productStatus": {
+            "draft": "Draf",
+            "published": "Dipublikasikan",
+            "proposed": "Diusulkan",
+            "rejected": "Ditolak"
+        },
+        "fields": {
+            "title": {
+                "label": "Judul",
+                "hint": "Beri judul produk Anda yang singkat dan jelas.<0/>50-60 karakter adalah panjang yang disarankan untuk mesin pencari.",
+                "placeholder": "Jaket musim dingin"
+            },
+            "subtitle": {
+                "label": "Subjudul",
+                "placeholder": "Hangat dan nyaman"
+            },
+            "handle": {
+                "label": "Handle",
+                "tooltip": "Handle digunakan untuk mereferensikan produk di etalase Anda. Jika tidak ditentukan, handle akan dibuat dari judul produk.",
+                "placeholder": "jaket-musim-dingin"
+            },
+            "description": {
+                "label": "Deskripsi",
+                "hint": "Beri deskripsi produk Anda yang singkat dan jelas.<0/>120-160 karakter adalah panjang yang disarankan untuk mesin pencari.",
+                "placeholder": "Jaket hangat dan nyaman"
+            },
+            "discountable": {
+                "label": "Dapat Diskon",
+                "hint": "Jika tidak dicentang, diskon tidak akan diterapkan pada produk ini"
+            },
+            "shipping_profile": {
+                "label": "Profil pengiriman",
+                "hint": "Hubungkan produk ke profil pengiriman"
+            },
+            "type": {
+                "label": "Jenis"
+            },
+            "collection": {
+                "label": "Koleksi"
+            },
+            "categories": {
+                "label": "Kategori"
+            },
+            "tags": {
+                "label": "Tag"
+            },
+            "sales_channels": {
+                "label": "Saluran penjualan",
+                "hint": "Produk ini hanya akan tersedia di saluran penjualan default jika dibiarkan apa adanya."
+            },
+            "countryOrigin": {
+                "label": "Negara asal"
+            },
+            "material": {
+                "label": "Bahan"
+            },
+            "width": {
+                "label": "Lebar"
+            },
+            "length": {
+                "label": "Panjang"
+            },
+            "height": {
+                "label": "Tinggi"
+            },
+            "weight": {
+                "label": "Berat"
+            },
+            "options": {
+                "label": "Opsi produk",
+                "hint": "Opsi digunakan untuk menentukan warna, ukuran, dll. dari produk",
+                "add": "Tambah opsi",
+                "optionTitle": "Judul opsi",
+                "optionTitlePlaceholder": "Warna",
+                "variations": "Variasi (dipisahkan koma)",
+                "variantionsPlaceholder": "Merah, Biru, Hijau"
+            },
+            "variants": {
+                "label": "Varian produk",
+                "hint": "Varian yang tidak dicentang tidak akan dibuat, peringkat ini akan memengaruhi peringkat varian di frontend Anda."
+            },
+            "mid_code": {
+                "label": "Kode MID"
+            },
+            "hs_code": {
+                "label": "Kode HS"
+            }
+        },
+        "variant": {
+            "edit": {
+                "header": "Edit Varian",
+                "success": "Varian produk berhasil diedit"
+            },
+            "create": {
+                "header": "Detail varian"
+            },
+            "deleteWarning": "Anda yakin ingin menghapus varian ini?",
+            "pricesPagination": "1 - {{current}} dari {{total}} harga",
+            "tableItemAvailable": "{{availableCount}} tersedia",
+            "tableItem_one": "{{availableCount}} tersedia di {{locationCount}} lokasi",
+            "tableItem_other": "{{availableCount}} tersedia di {{locationCount}} lokasi",
+            "inventory": {
+                "notManaged": "Tidak dikelola",
+                "manageItems": "Kelola item inventaris",
+                "notManagedDesc": "Inventaris tidak dikelola untuk varian ini. Aktifkan 'Kelola Inventaris' untuk melacak inventaris varian.",
+                "manageKit": "Kelola kit inventaris",
+                "navigateToItem": "Pergi ke item inventaris",
+                "actions": {
+                    "inventoryItems": "Pergi ke item inventaris",
+                    "inventoryKit": "Tampilkan item inventaris"
+                },
+                "inventoryKit": "Kit Inventaris",
+                "inventoryKitHint": "Apakah varian ini terdiri dari beberapa item inventaris?",
+                "validation": {
+                    "itemId": "Pilih item inventaris.",
+                    "quantity": "Kuantitas wajib diisi. Masukkan angka positif."
+                },
+                "header": "Stok & Inventaris",
+                "editItemDetails": "Edit detail item",
+                "manageInventoryLabel": "Kelola inventaris",
+                "manageInventoryHint": "Jika diaktifkan, kami akan mengubah kuantitas inventaris untuk Anda saat pesanan dan pengembalian dibuat.",
+                "allowBackordersLabel": "Izinkan pesanan kembali",
+                "allowBackordersHint": "Jika diaktifkan, pelanggan dapat membeli varian meskipun tidak ada kuantitas yang tersedia.",
+                "toast": {
+                    "levelsBatch": "Level inventaris diperbarui.",
+                    "update": "Item inventaris berhasil diperbarui.",
+                    "updateLevel": "Level inventaris berhasil diperbarui.",
+                    "itemsManageSuccess": "Item inventaris berhasil diperbarui."
+                }
+            }
+        },
+        "options": {
+            "header": "Opsi",
+            "edit": {
+                "header": "Edit Opsi",
+                "successToast": "Opsi {{title}} berhasil diperbarui."
+            },
+            "create": {
+                "header": "Buat Opsi",
+                "successToast": "Opsi {{title}} berhasil dibuat."
+            },
+            "deleteWarning": "Anda akan menghapus opsi produk: {{title}}. Tindakan ini tidak dapat dibatalkan."
+        },
+        "organization": {
+            "header": "Atur",
+            "edit": {
+                "header": "Edit Organisasi",
+                "toasts": {
+                    "success": "Berhasil memperbarui organisasi {{title}}."
+                }
+            }
+        },
+        "stock": {
+            "heading": "Kelola tingkat stok dan lokasi produk",
+            "description": "Perbarui tingkat inventaris stok untuk semua varian produk.",
+            "loading": "Tunggu sebentar, ini mungkin memakan waktu...",
+            "tooltips": {
+                "alreadyManaged": "Item inventaris ini sudah dapat diedit di bawah {{title}}.",
+                "alreadyManagedWithSku": "Item inventaris ini sudah dapat diedit di bawah {{title}} ({{sku}})."
+            }
+        },
+        "shippingProfile": {
+            "header": "Konfigurasi pengiriman",
+            "edit": {
+                "header": "Konfigurasi Pengiriman",
+                "toasts": {
+                    "success": "Berhasil memperbarui profil pengiriman untuk {{title}}."
+                }
+            },
+            "create": {
+                "errors": {
+                    "required": "Profil pengiriman wajib diisi"
+                }
+            }
+        },
+        "toasts": {
+            "delete": {
+                "success": {
+                    "header": "Produk dihapus",
+                    "description": "{{title}} berhasil dihapus."
+                },
+                "error": {
+                    "header": "Gagal menghapus produk"
+                }
+            }
+        }
+    },
+    "collections": {
+        "domain": "Koleksi",
+        "subtitle": "Atur produk ke dalam koleksi.",
+        "createCollection": "Buat Koleksi",
+        "createCollectionHint": "Buat koleksi baru untuk mengatur produk Anda.",
+        "createSuccess": "Koleksi berhasil dibuat.",
+        "editCollection": "Edit Koleksi",
+        "handleTooltip": "Handle digunakan untuk mereferensikan koleksi di etalase Anda. Jika tidak ditentukan, handle akan dibuat dari judul koleksi.",
+        "deleteWarning": "Anda akan menghapus koleksi {{title}}. Tindakan ini tidak dapat dibatalkan.",
+        "removeSingleProductWarning": "Anda akan menghapus produk {{title}} dari koleksi. Tindakan ini tidak dapat dibatalkan.",
+        "removeProductsWarning_one": "Anda akan menghapus {{count}} produk dari koleksi. Tindakan ini tidak dapat dibatalkan.",
+        "removeProductsWarning_other": "Anda akan menghapus {{count}} produk dari koleksi. Tindakan ini tidak dapat dibatalkan.",
+        "products": {
+            "list": {
+                "noRecordsMessage": "Tidak ada produk dalam koleksi."
+            },
+            "add": {
+                "successToast_one": "Produk berhasil ditambahkan ke koleksi.",
+                "successToast_other": "Produk berhasil ditambahkan ke koleksi."
+            },
+            "remove": {
+                "successToast_one": "Produk berhasil dihapus dari koleksi.",
+                "successToast_other": "Produk berhasil dihapus dari koleksi."
+            }
+        }
+    },
+    "categories": {
+        "domain": "Kategori",
+        "subtitle": "Atur produk ke dalam kategori, dan kelola peringkat dan hierarki kategori tersebut.",
+        "create": {
+            "header": "Buat Kategori",
+            "hint": "Buat kategori baru untuk mengatur produk Anda.",
+            "tabs": {
+                "details": "Detail",
+                "organize": "Atur Peringkat"
+            },
+            "successToast": "Kategori {{name}} berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Kategori",
+            "description": "Edit kategori untuk memperbarui detailnya.",
+            "successToast": "Kategori berhasil diperbarui."
+        },
+        "delete": {
+            "confirmation": "Anda akan menghapus kategori {{name}}. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Kategori {{name}} berhasil dihapus."
+        },
+        "products": {
+            "add": {
+                "disabledTooltip": "Produk sudah ada dalam kategori ini.",
+                "successToast_one": "Menambahkan {{count}} produk ke kategori.",
+                "successToast_other": "Menambahkan {{count}} produk ke kategori."
+            },
+            "remove": {
+                "confirmation_one": "Anda akan menghapus {{count}} produk dari kategori. Tindakan ini tidak dapat dibatalkan.",
+                "confirmation_other": "Anda akan menghapus {{count}} produk dari kategori. Tindakan ini tidak dapat dibatalkan.",
+                "successToast_one": "Menghapus {{count}} produk dari kategori.",
+                "successToast_other": "Menghapus {{count}} produk dari kategori."
+            },
+            "list": {
+                "noRecordsMessage": "Tidak ada produk dalam kategori."
+            }
+        },
+        "organize": {
+            "header": "Atur",
+            "action": "Edit peringkat"
+        },
+        "fields": {
+            "visibility": {
+                "label": "Visibilitas",
+                "internal": "Internal",
+                "public": "Publik"
+            },
+            "status": {
+                "label": "Status",
+                "active": "Aktif",
+                "inactive": "Tidak aktif"
+            },
+            "path": {
+                "label": "Path",
+                "tooltip": "Tampilkan path lengkap kategori."
+            },
+            "children": {
+                "label": "Anak-anak"
+            },
+            "new": {
+                "label": "Baru"
+            }
+        }
+    },
+    "inventory": {
+        "domain": "Inventaris",
+        "subtitle": "Kelola item inventaris Anda",
+        "reserved": "Dipesan",
+        "available": "Tersedia",
+        "locationLevels": "Lokasi",
+        "associatedVariants": "Varian terkait",
+        "manageLocations": "Kelola lokasi",
+        "manageLocationQuantity": "Kelola kuantitas lokasi",
+        "deleteWarning": "Anda akan menghapus item inventaris. Tindakan ini tidak dapat dibatalkan.",
+        "editItemDetails": "Edit detail item",
+        "quantityAcrossLocations": "{{quantity}} di {{locations}} lokasi",
+        "create": {
+            "title": "Buat Item Inventaris",
+            "details": "Detail",
+            "availability": "Ketersediaan",
+            "locations": "Lokasi",
+            "attributes": "Atribut",
+            "requiresShipping": "Membutuhkan pengiriman",
+            "requiresShippingHint": "Apakah item inventaris membutuhkan pengiriman?",
+            "successToast": "Item inventaris berhasil dibuat."
+        },
+        "reservation": {
+            "header": "Reservasi {{itemName}}",
+            "editItemDetails": "Edit reservasi",
+            "lineItemId": "ID Item Baris",
+            "orderID": "ID Pesanan",
+            "description": "Deskripsi",
+            "location": "Lokasi",
+            "inStockAtLocation": "Stok tersedia di lokasi ini",
+            "availableAtLocation": "Tersedia di lokasi ini",
+            "reservedAtLocation": "Dipesan di lokasi ini",
+            "reservedAmount": "Jumlah reservasi",
+            "create": "Buat reservasi",
+            "itemToReserve": "Item yang akan direservasi",
+            "quantityPlaceholder": "Berapa banyak yang ingin Anda reservasi?",
+            "descriptionPlaceholder": "Jenis reservasi apa ini?",
+            "successToast": "Reservasi berhasil dibuat.",
+            "updateSuccessToast": "Reservasi berhasil diperbarui.",
+            "deleteSuccessToast": "Reservasi berhasil dihapus.",
+            "errors": {
+                "noAvaliableQuantity": "Lokasi stok tidak memiliki kuantitas yang tersedia.",
+                "quantityOutOfRange": "Kuantitas minimum adalah 1 dan kuantitas maksimum adalah {{max}}"
+            }
+        },
+        "adjustInventory": {
+            "errors": {
+                "stockedQuantity": "Kuantitas stok tidak dapat diperbarui menjadi kurang dari kuantitas yang dipesan yaitu {{quantity}}."
+            }
+        },
+        "toast": {
+            "updateLocations": "Lokasi berhasil diperbarui.",
+            "updateLevel": "Tingkat inventaris berhasil diperbarui.",
+            "updateItem": "Item inventaris berhasil diperbarui."
+        },
+        "stock": {
+            "title": "Perbarui tingkat inventaris",
+            "description": "Perbarui tingkat inventaris stok untuk semua varian produk.",
+            "action": "Edit tingkat stok",
+            "placeholder": "Tidak diaktifkan",
+            "disablePrompt_one": "Anda akan menonaktifkan {{count}} tingkat lokasi. Tindakan ini tidak dapat dibatalkan.",
+            "disablePrompt_other": "Anda akan menonaktifkan {{count}} tingkat lokasi. Tindakan ini tidak dapat dibatalkan.",
+            "disabledToggleTooltip": "Tidak dapat menonaktifkan: kosongkan kuantitas masuk dan/atau dipesan sebelum menonaktifkan.",
+            "successToast": "Tingkat inventaris berhasil diperbarui."
+        }
+    },
+    "giftCards": {
+        "domain": "Kartu Hadiah",
+        "editGiftCard": "Edit Kartu Hadiah",
+        "createGiftCard": "Buat Kartu Hadiah",
+        "createGiftCardHint": "Buat kartu hadiah secara manual yang dapat digunakan sebagai metode pembayaran di toko Anda.",
+        "selectRegionFirst": "Pilih wilayah terlebih dahulu",
+        "deleteGiftCardWarning": "Anda akan menghapus kartu hadiah {{code}}. Tindakan ini tidak dapat dibatalkan.",
+        "balanceHigherThanValue": "Saldo tidak bisa lebih tinggi dari jumlah awal.",
+        "balanceLowerThanZero": "Saldo tidak bisa negatif.",
+        "expiryDateHint": "Negara memiliki hukum yang berbeda mengenai tanggal kedaluwarsa kartu hadiah. Pastikan untuk memeriksa peraturan setempat sebelum menetapkan tanggal kedaluwarsa.",
+        "regionHint": "Mengubah wilayah kartu hadiah juga akan mengubah mata uangnya, berpotensi memengaruhi nilai moneternya.",
+        "enabledHint": "Tentukan apakah kartu hadiah diaktifkan atau dinonaktifkan.",
+        "balance": "Saldo",
+        "currentBalance": "Saldo saat ini",
+        "initialBalance": "Saldo awal",
+        "personalMessage": "Pesan pribadi",
+        "recipient": "Penerima"
+    },
+    "customers": {
+        "domain": "Pelanggan",
+        "list": {
+            "noRecordsMessage": "Pelanggan Anda akan muncul di sini."
+        },
+        "create": {
+            "header": "Buat Pelanggan",
+            "hint": "Buat pelanggan baru dan kelola detailnya.",
+            "successToast": "Pelanggan {{email}} berhasil dibuat."
+        },
+        "groups": {
+            "label": "Grup pelanggan",
+            "remove": "Anda yakin ingin menghapus pelanggan dari grup pelanggan \"{{name}}\"?",
+            "removeMany": "Anda yakin ingin menghapus pelanggan dari grup pelanggan berikut: {{groups}}?",
+            "alreadyAddedTooltip": "Pelanggan sudah ada di grup pelanggan ini.",
+            "list": {
+                "noRecordsMessage": "Pelanggan ini tidak termasuk dalam grup mana pun."
+            },
+            "add": {
+                "success": "Pelanggan ditambahkan ke: {{groups}}.",
+                "list": {
+                    "noRecordsMessage": "Buat grup pelanggan terlebih dahulu."
+                }
+            },
+            "removed": {
+                "success": "Pelanggan dihapus dari: {{groups}}.",
+                "list": {
+                    "noRecordsMessage": "Buat grup pelanggan terlebih dahulu."
+                }
+            }
+        },
+        "edit": {
+            "header": "Edit Pelanggan",
+            "emailDisabledTooltip": "Alamat email tidak dapat diubah untuk pelanggan terdaftar.",
+            "successToast": "Pelanggan {{email}} berhasil diperbarui."
+        },
+        "delete": {
+            "title": "Hapus Pelanggan",
+            "description": "Anda akan menghapus pelanggan {{email}}. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Pelanggan {{email}} berhasil dihapus."
+        },
+        "fields": {
+            "guest": "Tamu",
+            "registered": "Terdaftar",
+            "groups": "Grup"
+        },
+        "registered": "Terdaftar",
+        "guest": "Tamu",
+        "hasAccount": "Punya akun",
+        "addresses": {
+            "title": "Alamat",
+            "fields": {
+                "addressName": "Nama alamat",
+                "address1": "Alamat 1",
+                "address2": "Alamat 2",
+                "city": "Kota",
+                "province": "Provinsi",
+                "postalCode": "Kode pos",
+                "country": "Negara",
+                "phone": "Telepon",
+                "company": "Perusahaan",
+                "countryCode": "Kode negara",
+                "provinceCode": "Kode provinsi"
+            },
+            "create": {
+                "header": "Buat Alamat",
+                "hint": "Buat alamat baru untuk pelanggan.",
+                "successToast": "Alamat berhasil dibuat."
+            }
+        }
+    },
+    "customerGroups": {
+        "domain": "Grup Pelanggan",
+        "subtitle": "Atur pelanggan ke dalam grup. Grup dapat memiliki promosi dan harga yang berbeda.",
+        "list": {
+            "empty": {
+                "heading": "Tidak ada grup pelanggan",
+                "description": "Tidak ada grup pelanggan untuk ditampilkan."
+            },
+            "filtered": {
+                "heading": "Tidak ada hasil",
+                "description": "Tidak ada grup pelanggan yang cocok dengan kriteria filter saat ini."
+            }
+        },
+        "create": {
+            "header": "Buat Grup Pelanggan",
+            "hint": "Buat grup pelanggan baru untuk segmentasi pelanggan Anda.",
+            "successToast": "Grup pelanggan {{name}} berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Grup Pelanggan",
+            "successToast": "Grup pelanggan {{name}} berhasil diperbarui."
+        },
+        "delete": {
+            "title": "Hapus Grup Pelanggan",
+            "description": "Anda akan menghapus grup pelanggan {{name}}. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Grup pelanggan {{name}} berhasil dihapus."
+        },
+        "customers": {
+            "alreadyAddedTooltip": "Pelanggan sudah ditambahkan ke grup.",
+            "add": {
+                "successToast_one": "Pelanggan berhasil ditambahkan ke grup.",
+                "successToast_other": "Pelanggan berhasil ditambahkan ke grup.",
+                "list": {
+                    "noRecordsMessage": "Buat pelanggan terlebih dahulu."
+                }
+            },
+            "remove": {
+                "title_one": "Hapus pelanggan",
+                "title_other": "Hapus pelanggan",
+                "description_one": "Anda akan menghapus {{count}} pelanggan dari grup pelanggan. Tindakan ini tidak dapat dibatalkan.",
+                "description_other": "Anda akan menghapus {{count}} pelanggan dari grup pelanggan. Tindakan ini tidak dapat dibatalkan."
+            },
+            "list": {
+                "noRecordsMessage": "Grup ini tidak memiliki pelanggan."
+            }
+        }
+    },
+    "orders": {
+        "domain": "Pesanan",
+        "claim": "Klaim",
+        "exchange": "Tukar",
+        "return": "Kembalikan",
+        "cancelWarning": "Anda akan membatalkan pesanan {{id}}. Tindakan ini tidak dapat dibatalkan.",
+        "orderCanceled": "Pesanan berhasil dibatalkan",
+        "onDateFromSalesChannel": "{{date}} dari {{salesChannel}}",
+        "list": {
+            "noRecordsMessage": "Pesanan Anda akan muncul di sini."
+        },
+        "status": {
+            "not_paid": "Belum dibayar",
+            "pending": "Tertunda",
+            "completed": "Selesai",
+            "draft": "Draf",
+            "archived": "Diararsip",
+            "canceled": "Dibatalkan",
+            "requires_action": "Membutuhkan tindakan"
+        },
+        "summary": {
+            "requestReturn": "Minta pengembalian",
+            "allocateItems": "Alokasikan item",
+            "editOrder": "Edit pesanan",
+            "editOrderContinue": "Lanjutkan edit pesanan",
+            "inventoryKit": "Terdiri dari {{count}}x item inventaris",
+            "itemTotal": "Total Item",
+            "shippingTotal": "Total Pengiriman",
+            "discountTotal": "Total Diskon",
+            "taxTotalIncl": "Total Pajak (termasuk)",
+            "itemSubtotal": "Subtotal Item",
+            "shippingSubtotal": "Subtotal Pengiriman",
+            "discountSubtotal": "Subtotal Diskon",
+            "taxTotal": "Total Pajak"
+        },
+        "transfer": {
+            "title": "Transfer kepemilikan",
+            "requestSuccess": "Permintaan transfer pesanan dikirim ke: {{email}}.",
+            "currentOwner": "Pemilik saat ini",
+            "newOwner": "Pemilik baru",
+            "currentOwnerDescription": "Pelanggan yang saat ini terkait dengan pesanan ini.",
+            "newOwnerDescription": "Pelanggan yang akan menerima transfer pesanan ini."
+        },
+        "payment": {
+            "title": "Pembayaran",
+            "isReadyToBeCaptured": "Pembayaran <0/> siap untuk diambil.",
+            "totalPaidByCustomer": "Total dibayar oleh pelanggan",
+            "capture": "Ambil pembayaran",
+            "capture_short": "Ambil",
+            "refund": "Pengembalian dana",
+            "markAsPaid": "Tandai sebagai dibayar",
+            "statusLabel": "Status pembayaran",
+            "statusTitle": "Status Pembayaran",
+            "status": {
+                "notPaid": "Belum dibayar",
+                "authorized": "Diotorisasi",
+                "partiallyAuthorized": "Sebagian diotorisasi",
+                "awaiting": "Menunggu",
+                "captured": "Diambil",
+                "partiallyRefunded": "Sebagian dikembalikan",
+                "partiallyCaptured": "Sebagian diambil",
+                "refunded": "Dikembalikan",
+                "canceled": "Dibatalkan",
+                "requiresAction": "Membutuhkan tindakan"
+            },
+            "capturePayment": "Pembayaran sebesar {{amount}} akan diambil.",
+            "capturePaymentSuccess": "Pembayaran sebesar {{amount}} berhasil diambil",
+            "markAsPaidPayment": "Pembayaran sebesar {{amount}} akan ditandai sebagai dibayar.",
+            "markAsPaidPaymentSuccess": "Pembayaran sebesar {{amount}} berhasil ditandai sebagai dibayar",
+            "createRefund": "Buat Pengembalian Dana",
+            "refundPaymentSuccess": "Pengembalian dana sebesar {{amount}} berhasil",
+            "createRefundWrongQuantity": "Kuantitas harus berupa angka antara 1 dan {{number}}",
+            "refundAmount": "Pengembalian dana {{ amount }}",
+            "paymentLink": "Salin tautan pembayaran untuk {{ amount }}",
+            "selectPaymentToRefund": "Pilih pembayaran untuk dikembalikan"
+        },
+        "edits": {
+            "title": "Edit pesanan",
+            "confirm": "Konfirmasi Edit",
+            "confirmText": "Anda akan mengonfirmasi Edit Pesanan. Tindakan ini tidak dapat dibatalkan.",
+            "cancel": "Batalkan Edit",
+            "currentItems": "Item saat ini",
+            "currentItemsDescription": "Sesuaikan kuantitas item atau hapus.",
+            "addItemsDescription": "Anda dapat menambah item baru ke pesanan.",
+            "addItems": "Tambah item",
+            "amountPaid": "Jumlah dibayar",
+            "newTotal": "Total baru",
+            "differenceDue": "Selisih terutang",
+            "create": "Edit Pesanan",
+            "currentTotal": "Total saat ini",
+            "noteHint": "Tambah catatan internal untuk edit",
+            "cancelSuccessToast": "Edit pesanan dibatalkan",
+            "createSuccessToast": "Permintaan edit pesanan dibuat",
+            "activeChangeError": "Sudah ada perubahan pesanan yang aktif pada pesanan (pengembalian, klaim, penukaran, dll.). Selesaikan atau batalkan perubahan sebelum mengedit pesanan.",
+            "panel": {
+                "title": "Edit pesanan diminta",
+                "titlePending": "Edit pesanan tertunda"
+            },
+            "toast": {
+                "canceledSuccessfully": "Edit pesanan dibatalkan",
+                "confirmedSuccessfully": "Edit pesanan dikonfirmasi"
+            },
+            "validation": {
+                "quantityLowerThanFulfillment": "Tidak dapat mengatur kuantitas menjadi kurang dari atau sama dengan kuantitas terpenuhi"
+            }
+        },
+        "edit": {
+            "email": {
+                "title": "Edit email",
+                "requestSuccess": "Email pesanan diperbarui menjadi {{email}}."
+            },
+            "shippingAddress": {
+                "title": "Edit alamat pengiriman",
+                "requestSuccess": "Alamat pengiriman pesanan diperbarui."
+            },
+            "billingAddress": {
+                "title": "Edit alamat penagihan",
+                "requestSuccess": "Alamat penagihan pesanan diperbarui."
+            }
+        },
+        "returns": {
+            "create": "Buat Pengembalian",
+            "confirm": "Konfirmasi Pengembalian",
+            "confirmText": "Anda akan mengonfirmasi Pengembalian. Tindakan ini tidak dapat dibatalkan.",
+            "inbound": "Masuk",
+            "outbound": "Keluar",
+            "sendNotification": "Kirim notifikasi",
+            "sendNotificationHint": "Beritahu pelanggan tentang pengembalian.",
+            "returnTotal": "Total pengembalian",
+            "inboundTotal": "Total masuk",
+            "estDifference": "Perkiraan selisih",
+            "outstandingAmount": "Jumlah terutang",
+            "reason": "Alasan",
+            "reasonHint": "Pilih alasan mengapa pelanggan ingin mengembalikan item.",
+            "note": "Catatan",
+            "noInventoryLevel": "Tidak ada level inventaris",
+            "noInventoryLevelDesc": "Lokasi stok yang dipilih tidak memiliki level inventaris untuk item yang dipilih. Pengembalian dapat diminta tetapi tidak dapat diterima sampai level inventaris dibuat untuk lokasi yang dipilih.",
+            "noteHint": "Anda dapat mengetik bebas jika ingin menentukan sesuatu.",
+            "location": "Lokasi",
+            "locationHint": "Pilih lokasi mana yang ingin Anda kembalikan item.",
+            "inboundShipping": "Pengiriman pengembalian",
+            "inboundShippingHint": "Pilih metode yang ingin Anda gunakan.",
+            "returnableQuantityLabel": "Kuantitas dapat dikembalikan",
+            "refundableAmountLabel": "Jumlah dapat dikembalikan",
+            "returnRequestedInfo": "{{requestedItemsCount}}x item diminta pengembalian",
+            "returnReceivedInfo": "{{requestedItemsCount}}x item pengembalian diterima",
+            "itemReceived": "Item diterima",
+            "returnRequested": "Pengembalian diminta",
+            "damagedItemReceived": "Item rusak diterima",
+            "damagedItemsReturned": "{{quantity}}x item rusak dikembalikan",
+            "activeChangeError": "Ada perubahan pesanan aktif yang sedang berlangsung pada pesanan ini. Selesaikan atau batalkan perubahan terlebih dahulu.",
+            "cancel": {
+                "title": "Batalkan Pengembalian",
+                "description": "Anda yakin ingin membatalkan permintaan pengembalian?"
+            },
+            "placeholders": {
+                "noReturnShippingOptions": {
+                    "title": "Tidak ada opsi pengiriman pengembalian ditemukan",
+                    "hint": "Tidak ada opsi pengiriman pengembalian yang dibuat untuk lokasi ini. Anda dapat membuatnya di <LinkComponent>Lokasi & Pengiriman</LinkComponent>."
+                },
+                "outboundShippingOptions": {
+                    "title": "Tidak ada opsi pengiriman keluar ditemukan",
+                    "hint": "Tidak ada opsi pengiriman keluar yang dibuat untuk lokasi ini. Anda dapat membuatnya di <LinkComponent>Lokasi & Pengiriman</LinkComponent>."
+                }
+            },
+            "receive": {
+                "action": "Terima item",
+                "receiveItems": "{{ returnType }} {{ id }}",
+                "restockAll": "Restok semua item",
+                "itemsLabel": "Item diterima",
+                "title": "Terima item untuk #{{returnId}}",
+                "sendNotificationHint": "Beritahu pelanggan tentang pengembalian yang diterima.",
+                "inventoryWarning": "Perhatikan bahwa kami akan secara otomatis menyesuaikan tingkat inventaris berdasarkan input Anda di atas.",
+                "writeOffInputLabel": "Berapa banyak item yang rusak?",
+                "toast": {
+                    "success": "Pengembalian berhasil diterima.",
+                    "errorLargeValue": "Kuantitas lebih besar dari kuantitas item yang diminta.",
+                    "errorNegativeValue": "Kuantitas tidak bisa negatif.",
+                    "errorLargeDamagedValue": "Kuantitas item rusak + kuantitas diterima tidak rusak melebihi total kuantitas item pada pengembalian. Kurangi kuantitas item tidak rusak."
+                }
+            },
+            "toast": {
+                "canceledSuccessfully": "Pengembalian berhasil dibatalkan",
+                "confirmedSuccessfully": "Pengembalian berhasil dikonfirmasi"
+            },
+            "panel": {
+                "title": "Pengembalian dimulai",
+                "description": "Ada permintaan pengembalian terbuka yang harus diselesaikan"
+            }
+        },
+        "claims": {
+            "create": "Buat Klaim",
+            "confirm": "Konfirmasi Klaim",
+            "confirmText": "Anda akan mengonfirmasi Klaim. Tindakan ini tidak dapat dibatalkan.",
+            "manage": "Kelola Klaim",
+            "outbound": "Keluar",
+            "outboundItemAdded": "{{itemsCount}}x ditambahkan melalui klaim",
+            "outboundTotal": "Total keluar",
+            "outboundShipping": "Pengiriman keluar",
+            "outboundShippingHint": "Pilih metode yang ingin Anda gunakan.",
+            "refundAmount": "Perkiraan selisih",
+            "activeChangeError": "Ada perubahan pesanan aktif pada pesanan ini. Selesaikan atau buang perubahan sebelumnya.",
+            "actions": {
+                "cancelClaim": {
+                    "successToast": "Klaim berhasil dibatalkan."
+                }
+            },
+            "cancel": {
+                "title": "Batalkan Klaim",
+                "description": "Anda yakin ingin membatalkan klaim?"
+            },
+            "tooltips": {
+                "onlyReturnShippingOptions": "Daftar ini hanya akan terdiri dari opsi pengiriman pengembalian."
+            },
+            "toast": {
+                "canceledSuccessfully": "Klaim berhasil dibatalkan",
+                "confirmedSuccessfully": "Klaim berhasil dikonfirmasi"
+            },
+            "panel": {
+                "title": "Klaim dimulai",
+                "description": "Ada permintaan klaim terbuka yang harus diselesaikan"
+            }
+        },
+        "exchanges": {
+            "create": "Buat Penukaran",
+            "manage": "Kelola Penukaran",
+            "confirm": "Konfirmasi Penukaran",
+            "confirmText": "Anda akan mengonfirmasi Penukaran. Tindakan ini tidak dapat dibatalkan.",
+            "outbound": "Keluar",
+            "outboundItemAdded": "{{itemsCount}}x ditambahkan melalui penukaran",
+            "outboundTotal": "Total keluar",
+            "outboundShipping": "Pengiriman keluar",
+            "outboundShippingHint": "Pilih metode yang ingin Anda gunakan.",
+            "refundAmount": "Perkiraan selisih",
+            "activeChangeError": "Ada perubahan pesanan aktif pada pesanan ini. Selesaikan atau buang perubahan sebelumnya.",
+            "actions": {
+                "cancelExchange": {
+                    "successToast": "Penukaran berhasil dibatalkan."
+                }
+            },
+            "cancel": {
+                "title": "Batalkan Penukaran",
+                "description": "Anda yakin ingin membatalkan penukaran?"
+            },
+            "tooltips": {
+                "onlyReturnShippingOptions": "Daftar ini hanya akan terdiri dari opsi pengiriman pengembalian."
+            },
+            "toast": {
+                "canceledSuccessfully": "Penukaran berhasil dibatalkan",
+                "confirmedSuccessfully": "Penukaran berhasil dikonfirmasi"
+            },
+            "panel": {
+                "title": "Penukaran dimulai",
+                "description": "Ada permintaan penukaran terbuka yang harus diselesaikan"
+            }
+        },
+        "reservations": {
+            "allocatedLabel": "Dialokasikan",
+            "notAllocatedLabel": "Tidak dialokasikan"
+        },
+        "allocateItems": {
+            "action": "Alokasikan item",
+            "title": "Alokasikan item pesanan",
+            "locationDescription": "Pilih lokasi mana yang ingin Anda alokasikan.",
+            "itemsToAllocate": "Item yang akan dialokasikan",
+            "itemsToAllocateDesc": "Pilih jumlah item yang ingin Anda alokasikan",
+            "search": "Cari item",
+            "consistsOf": "Terdiri dari {{num}}x item inventaris",
+            "requires": "Membutuhkan {{num}} per varian",
+            "toast": {
+                "created": "Item berhasil dialokasikan"
+            },
+            "error": {
+                "quantityNotAllocated": "Ada item yang belum dialokasikan."
+            }
+        },
+        "shipment": {
+            "title": "Tandai pengiriman terpenuhi",
+            "trackingNumber": "Nomor pelacakan",
+            "addTracking": "Tambah nomor pelacakan",
+            "sendNotification": "Kirim notifikasi",
+            "sendNotificationHint": "Beritahu pelanggan tentang pengiriman ini.",
+            "toastCreated": "Pengiriman berhasil dibuat."
+        },
+        "fulfillment": {
+            "cancelWarning": "Anda akan membatalkan pemenuhan. Tindakan ini tidak dapat dibatalkan.",
+            "markAsDeliveredWarning": "Anda akan menandai pemenuhan sebagai terkirim. Tindakan ini tidak dapat dibatalkan.",
+            "differentOptionSelected": "Opsi pengiriman yang dipilih berbeda dengan yang dipilih pelanggan.",
+            "disabledItemTooltip": "Opsi pengiriman yang Anda pilih tidak mengizinkan pemenuhan item ini",
+            "unfulfilledItems": "Item Belum Terpenuhi",
+            "statusLabel": "Status pemenuhan",
+            "statusTitle": "Status Pemenuhan",
+            "fulfillItems": "Penuhi item",
+            "awaitingFulfillmentBadge": "Menunggu pemenuhan",
+            "requiresShipping": "Membutuhkan pengiriman",
+            "number": "Pemenuhan #{{number}}",
+            "itemsToFulfill": "Item untuk dipenuhi",
+            "create": "Buat Pemenuhan",
+            "available": "Tersedia",
+            "inStock": "Stok tersedia",
+            "markAsShipped": "Tandai sebagai dikirim",
+            "markAsPickedUp": "Tandai sebagai diambil",
+            "markAsDelivered": "Tandai sebagai terkirim",
+            "itemsToFulfillDesc": "Pilih item dan kuantitas untuk dipenuhi",
+            "locationDescription": "Pilih lokasi mana yang ingin Anda penuhi item.",
+            "sendNotificationHint": "Beritahu pelanggan tentang pemenuhan yang dibuat.",
+            "methodDescription": "Pilih metode pengiriman yang berbeda dari yang dipilih pelanggan",
+            "error": {
+                "wrongQuantity": "Hanya satu item yang tersedia untuk pemenuhan",
+                "wrongQuantity_other": "Kuantitas harus berupa angka antara 1 dan {{number}}",
+                "noItems": "Tidak ada item untuk dipenuhi.",
+                "noShippingOption": "Opsi pengiriman wajib diisi",
+                "noLocation": "Lokasi wajib diisi"
+            },
+            "status": {
+                "notFulfilled": "Belum terpenuhi",
+                "partiallyFulfilled": "Sebagian terpenuhi",
+                "fulfilled": "Terpenuhi",
+                "partiallyShipped": "Sebagian dikirim",
+                "shipped": "Dikirim",
+                "delivered": "Terkirim",
+                "partiallyDelivered": "Sebagian terkirim",
+                "partiallyReturned": "Sebagian dikembalikan",
+                "returned": "Dikembalikan",
+                "canceled": "Dibatalkan",
+                "requiresAction": "Membutuhkan tindakan"
+            },
+            "toast": {
+                "created": "Pemenuhan berhasil dibuat",
+                "canceled": "Pemenuhan berhasil dibatalkan",
+                "fulfillmentShipped": "Tidak dapat membatalkan pemenuhan yang sudah dikirim",
+                "fulfillmentDelivered": "Pemenuhan berhasil ditandai sebagai terkirim",
+                "fulfillmentPickedUp": "Pemenuhan berhasil ditandai sebagai diambil"
+            },
+            "trackingLabel": "Pelacakan",
+            "shippingFromLabel": "Dikirim dari",
+            "itemsLabel": "Item"
+        },
+        "refund": {
+            "title": "Buat Pengembalian Dana",
+            "sendNotificationHint": "Beritahu pelanggan tentang pengembalian dana yang dibuat.",
+            "systemPayment": "Pembayaran sistem",
+            "systemPaymentDesc": "Satu atau lebih pembayaran Anda adalah pembayaran sistem. Perlu diketahui, pengambilan dan pengembalian dana tidak ditangani oleh Medusa untuk pembayaran tersebut.",
+            "error": {
+                "amountToLarge": "Tidak dapat mengembalikan dana lebih dari jumlah pesanan awal.",
+                "amountNegative": "Jumlah pengembalian dana harus berupa angka positif.",
+                "reasonRequired": "Pilih alasan pengembalian dana."
+            }
+        },
+        "customer": {
+            "contactLabel": "Kontak",
+            "editEmail": "Edit email",
+            "transferOwnership": "Transfer kepemilikan",
+            "editBillingAddress": "Edit alamat penagihan",
+            "editShippingAddress": "Edit alamat pengiriman"
+        },
+        "activity": {
+            "header": "Aktivitas",
+            "showMoreActivities_one": "Tampilkan {{count}} aktivitas lagi",
+            "showMoreActivities_other": "Tampilkan {{count}} aktivitas lagi",
+            "comment": {
+                "label": "Komentar",
+                "placeholder": "Tinggalkan komentar",
+                "addButtonText": "Tambah komentar",
+                "deleteButtonText": "Hapus komentar"
+            },
+            "from": "Dari",
+            "to": "Kepada",
+            "events": {
+                "common": {
+                    "toReturn": "Untuk dikembalikan",
+                    "toSend": "Untuk dikirim"
+                },
+                "placed": {
+                    "title": "Pesanan ditempatkan",
+                    "fromSalesChannel": "dari {{salesChannel}}"
+                },
+                "canceled": {
+                    "title": "Pesanan dibatalkan"
+                },
+                "payment": {
+                    "awaiting": "Menunggu pembayaran",
+                    "captured": "Pembayaran diambil",
+                    "canceled": "Pembayaran dibatalkan",
+                    "refunded": "Pembayaran dikembalikan"
+                },
+                "fulfillment": {
+                    "created": "Item terpenuhi",
+                    "canceled": "Pemenuhan dibatalkan",
+                    "shipped": "Item dikirim",
+                    "delivered": "Item terkirim",
+                    "items_one": "{{count}} item",
+                    "items_other": "{{count}} item"
+                },
+                "return": {
+                    "created": "Pengembalian #{{returnId}} diminta",
+                    "canceled": "Pengembalian #{{returnId}} dibatalkan",
+                    "received": "Pengembalian #{{returnId}} diterima",
+                    "items_one": "{{count}} item dikembalikan",
+                    "items_other": "{{count}} item dikembalikan"
+                },
+                "note": {
+                    "comment": "Komentar",
+                    "byLine": "oleh {{author}}"
+                },
+                "claim": {
+                    "created": "Klaim #{{claimId}} diminta",
+                    "canceled": "Klaim #{{claimId}} dibatalkan",
+                    "itemsInbound": "{{count}} item untuk dikembalikan",
+                    "itemsOutbound": "{{count}} item untuk dikirim"
+                },
+                "exchange": {
+                    "created": "Penukaran #{{exchangeId}} diminta",
+                    "canceled": "Penukaran #{{exchangeId}} dibatalkan",
+                    "itemsInbound": "{{count}} item untuk dikembalikan",
+                    "itemsOutbound": "{{count}} item untuk dikirim"
+                },
+                "edit": {
+                    "requested": "Edit pesanan #{{editId}} diminta",
+                    "confirmed": "Edit pesanan #{{editId}} dikonfirmasi"
+                },
+                "transfer": {
+                    "requested": "Transfer pesanan #{{transferId}} diminta",
+                    "confirmed": "Transfer pesanan #{{transferId}} dikonfirmasi",
+                    "declined": "Transfer pesanan #{{transferId}} ditolak"
+                },
+                "update_order": {
+                    "shipping_address": "Alamat pengiriman diperbarui",
+                    "billing_address": "Alamat penagihan diperbarui",
+                    "email": "Email diperbarui"
+                }
+            }
+        },
+        "fields": {
+            "displayId": "ID Tampilan",
+            "refundableAmount": "Jumlah dapat dikembalikan",
+            "returnableQuantity": "Kuantitas dapat dikembalikan"
+        }
+    },
+    "draftOrders": {
+        "domain": "Draf Pesanan",
+        "deleteWarning": "Anda akan menghapus draf pesanan {{id}}. Tindakan ini tidak dapat dibatalkan.",
+        "paymentLinkLabel": "Tautan pembayaran",
+        "cartIdLabel": "ID Keranjang",
+        "markAsPaid": {
+            "label": "Tandai sebagai dibayar",
+            "warningTitle": "Tandai sebagai Dibayar",
+            "warningDescription": "Anda akan menandai draf pesanan sebagai dibayar. Tindakan ini tidak dapat dibatalkan, dan menagih pembayaran tidak akan mungkin dilakukan nanti."
+        },
+        "status": {
+            "open": "Buka",
+            "completed": "Selesai"
+        },
+        "create": {
+            "createDraftOrder": "Buat Draf Pesanan",
+            "createDraftOrderHint": "Buat draf pesanan baru untuk mengelola detail pesanan sebelum ditempatkan.",
+            "chooseRegionHint": "Pilih wilayah",
+            "existingItemsLabel": "Item yang sudah ada",
+            "existingItemsHint": "Tambah produk yang sudah ada ke draf pesanan.",
+            "customItemsLabel": "Item kustom",
+            "customItemsHint": "Tambah item kustom ke draf pesanan.",
+            "addExistingItemsAction": "Tambah item yang sudah ada",
+            "addCustomItemAction": "Tambah item kustom",
+            "noCustomItemsAddedLabel": "Belum ada item kustom ditambahkan",
+            "noExistingItemsAddedLabel": "Belum ada item yang sudah ada ditambahkan",
+            "chooseRegionTooltip": "Pilih wilayah terlebih dahulu",
+            "useExistingCustomerLabel": "Gunakan pelanggan yang sudah ada",
+            "addShippingMethodsAction": "Tambah metode pengiriman",
+            "unitPriceOverrideLabel": "Timpa harga satuan",
+            "shippingOptionLabel": "Opsi pengiriman",
+            "shippingOptionHint": "Pilih opsi pengiriman untuk draf pesanan.",
+            "shippingPriceOverrideLabel": "Timpa harga pengiriman",
+            "shippingPriceOverrideHint": "Timpa harga pengiriman untuk draf pesanan.",
+            "sendNotificationLabel": "Kirim notifikasi",
+            "sendNotificationHint": "Kirim notifikasi ke pelanggan saat draf pesanan dibuat."
+        },
+        "validation": {
+            "requiredEmailOrCustomer": "Email atau pelanggan wajib diisi.",
+            "requiredItems": "Setidaknya satu item wajib diisi.",
+            "invalidEmail": "Email harus berupa alamat email yang valid."
+        }
+    },
+    "stockLocations": {
+        "domain": "Lokasi & Pengiriman",
+        "list": {
+            "description": "Kelola lokasi stok dan opsi pengiriman toko Anda."
+        },
+        "create": {
+            "header": "Buat Lokasi Stok",
+            "hint": "Lokasi stok adalah situs fisik tempat produk disimpan dan dikirim.",
+            "successToast": "Lokasi {{name}} berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Lokasi Stok",
+            "viewInventory": "Lihat inventaris",
+            "successToast": "Lokasi {{name}} berhasil diperbarui."
+        },
+        "delete": {
+            "confirmation": "Anda akan menghapus lokasi stok \"{{name}}\". Tindakan ini tidak dapat dibatalkan."
+        },
+        "fulfillmentProviders": {
+            "header": "Penyedia Pemenuhan",
+            "shippingOptionsTooltip": "Dropdown ini hanya akan berisi penyedia yang diaktifkan untuk lokasi ini. Tambahkan mereka ke lokasi jika dropdown dinonaktifkan.",
+            "label": "Penyedia pemenuhan terhubung",
+            "connectedTo": "Terhubung ke {{count}} dari {{total}} penyedia pemenuhan",
+            "noProviders": "Lokasi Stok ini tidak terhubung ke penyedia pemenuhan mana pun.",
+            "action": "Hubungkan Penyedia",
+            "successToast": "Penyedia pemenuhan untuk lokasi stok berhasil diperbarui."
+        },
+        "fulfillmentSets": {
+            "pickup": {
+                "header": "Ambil"
+            },
+            "shipping": {
+                "header": "Pengiriman"
+            },
+            "disable": {
+                "confirmation": "Anda yakin ingin menonaktifkan \"{{name}}\"? Ini akan menghapus semua zona layanan dan opsi pengiriman terkait, dan tidak dapat dibatalkan.",
+                "pickup": "Pengambilan berhasil dinonaktifkan.",
+                "shipping": "Pengiriman berhasil dinonaktifkan."
+            },
+            "enable": {
+                "pickup": "Pengambilan berhasil diaktifkan.",
+                "shipping": "Pengiriman berhasil diaktifkan."
+            }
+        },
+        "sidebar": {
+            "header": "Konfigurasi Pengiriman",
+            "shippingProfiles": {
+                "label": "Profil Pengiriman",
+                "description": "Kelompokkan produk berdasarkan persyaratan pengiriman"
+            }
+        },
+        "salesChannels": {
+            "header": "Saluran Penjualan",
+            "hint": "Kelola saluran penjualan yang terhubung ke lokasi ini.",
+            "label": "Saluran penjualan terhubung",
+            "connectedTo": "Terhubung ke {{count}} dari {{total}} saluran penjualan",
+            "noChannels": "Lokasi tidak terhubung ke saluran penjualan mana pun.",
+            "action": "Hubungkan saluran penjualan",
+            "successToast": "Saluran penjualan berhasil diperbarui."
+        },
+        "pickupOptions": {
+            "edit": {
+                "header": "Edit Opsi Pengambilan"
+            }
+        },
+        "shippingOptions": {
+            "create": {
+                "shipping": {
+                    "header": "Buat Opsi Pengiriman untuk {{zone}}",
+                    "hint": "Buat opsi pengiriman baru untuk menentukan cara produk dikirim dari lokasi ini.",
+                    "label": "Opsi pengiriman",
+                    "successToast": "Opsi pengiriman {{name}} berhasil dibuat."
+                },
+                "pickup": {
+                    "header": "Buat Opsi Pengambilan untuk {{zone}}",
+                    "hint": "Buat opsi pengambilan baru untuk menentukan cara produk diambil dari lokasi ini.",
+                    "label": "Opsi pengambilan",
+                    "successToast": "Opsi pengambilan {{name}} berhasil dibuat."
+                },
+                "returns": {
+                    "header": "Buat Opsi Pengembalian untuk {{zone}}",
+                    "hint": "Buat opsi pengembalian baru untuk menentukan cara produk dikembalikan ke lokasi ini.",
+                    "label": "Opsi pengembalian",
+                    "successToast": "Opsi pengembalian {{name}} berhasil dibuat."
+                },
+                "tabs": {
+                    "details": "Detail",
+                    "prices": "Harga"
+                },
+                "action": "Buat opsi"
+            },
+            "delete": {
+                "confirmation": "Anda akan menghapus opsi pengiriman \"{{name}}\". Tindakan ini tidak dapat dibatalkan.",
+                "successToast": "Opsi pengiriman {{name}} berhasil dihapus."
+            },
+            "edit": {
+                "header": "Edit Opsi Pengiriman",
+                "action": "Edit opsi",
+                "successToast": "Opsi pengiriman {{name}} berhasil diperbarui."
+            },
+            "pricing": {
+                "action": "Edit harga"
+            },
+            "conditionalPrices": {
+                "header": "Harga Bersyarat untuk {{name}}",
+                "description": "Kelola harga bersyarat untuk opsi pengiriman ini berdasarkan total item keranjang.",
+                "attributes": {
+                    "cartItemTotal": "Total item keranjang"
+                },
+                "summaries": {
+                    "range": "Jika <0>{{attribute}}</0> antara <1>{{gte}}</1> dan <2>{{lte}}</2>",
+                    "greaterThan": "Jika <0>{{attribute}}</0> ≥ <1>{{gte}}</1>",
+                    "lessThan": "Jika <0>{{attribute}}</0> ≤ <1>{{lte}}</1>"
+                },
+                "actions": {
+                    "addPrice": "Tambah harga",
+                    "manageConditionalPrices": "Kelola harga bersyarat"
+                },
+                "rules": {
+                    "amount": "Harga opsi pengiriman",
+                    "gte": "Total item keranjang minimum",
+                    "lte": "Total item keranjang maksimum"
+                },
+                "customRules": {
+                    "label": "Aturan kustom",
+                    "tooltip": "Harga bersyarat ini memiliki aturan yang tidak dapat dikelola di dasbor.",
+                    "eq": "Total item keranjang harus sama dengan",
+                    "gt": "Total item keranjang harus lebih besar dari",
+                    "lt": "Total item keranjang harus kurang dari"
+                },
+                "errors": {
+                    "amountRequired": "Harga opsi pengiriman wajib diisi",
+                    "minOrMaxRequired": "Setidaknya salah satu dari total item keranjang minimum atau maksimum harus disediakan",
+                    "minGreaterThanMax": "Total item keranjang minimum harus kurang dari atau sama dengan total item keranjang maksimum",
+                    "duplicateAmount": "Harga opsi pengiriman harus unik untuk setiap kondisi",
+                    "overlappingConditions": "Kondisi harus unik di semua aturan harga"
+                }
+            },
+            "fields": {
+                "count": {
+                    "shipping_one": "{{count}} opsi pengiriman",
+                    "shipping_other": "{{count}} opsi pengiriman",
+                    "pickup_one": "{{count}} opsi pengambilan",
+                    "pickup_other": "{{count}} opsi pengambilan",
+                    "returns_one": "{{count}} opsi pengembalian",
+                    "returns_other": "{{count}} opsi pengembalian"
+                },
+                "priceType": {
+                    "label": "Jenis harga",
+                    "options": {
+                        "fixed": {
+                            "label": "Tetap",
+                            "hint": "Harga opsi pengiriman ditetapkan dan tidak berubah berdasarkan isi pesanan."
+                        },
+                        "calculated": {
+                            "label": "Dihitung",
+                            "hint": "Harga opsi pengiriman dihitung oleh penyedia pemenuhan selama checkout."
+                        }
+                    }
+                },
+                "enableInStore": {
+                    "label": "Aktifkan di toko",
+                    "hint": "Apakah pelanggan dapat menggunakan opsi ini saat checkout."
+                },
+                "provider": "Penyedia pemenuhan",
+                "profile": "Profil pengiriman",
+                "fulfillmentOption": "Opsi pemenuhan"
+            }
+        },
+        "serviceZones": {
+            "create": {
+                "headerPickup": "Buat Zona Layanan untuk Pengambilan dari {{location}}",
+                "headerShipping": "Buat Zona Layanan untuk Pengiriman dari {{location}}",
+                "action": "Buat zona layanan",
+                "successToast": "Zona layanan {{name}} berhasil dibuat."
+            },
+            "edit": {
+                "header": "Edit Zona Layanan",
+                "successToast": "Zona layanan {{name}} berhasil diperbarui."
+            },
+            "delete": {
+                "confirmation": "Anda akan menghapus zona layanan \"{{name}}\". Tindakan ini tidak dapat dibatalkan.",
+                "successToast": "Zona layanan {{name}} berhasil dihapus."
+            },
+            "manageAreas": {
+                "header": "Kelola Area untuk {{name}}",
+                "action": "Kelola area",
+                "label": "Area",
+                "hint": "Pilih area geografis yang dicakup oleh zona layanan.",
+                "successToast": "Area untuk {{name}} berhasil diperbarui."
+            },
+            "fields": {
+                "noRecords": "Tidak ada zona layanan untuk ditambahkan opsi pengiriman.",
+                "tip": "Zona layanan adalah kumpulan zona atau area geografis. Ini digunakan untuk membatasi opsi pengiriman yang tersedia untuk sekumpulan lokasi yang ditentukan."
+            }
+        }
+    },
+    "shippingProfile": {
+        "domain": "Profil Pengiriman",
+        "subtitle": "Kelompokkan produk dengan persyaratan pengiriman yang serupa ke dalam profil.",
+        "create": {
+            "header": "Buat Profil Pengiriman",
+            "hint": "Buat profil pengiriman baru untuk mengelompokkan produk dengan persyaratan pengiriman yang serupa.",
+            "successToast": "Profil pengiriman {{name}} berhasil dibuat."
+        },
+        "delete": {
+            "title": "Hapus Profil Pengiriman",
+            "description": "Anda akan menghapus profil pengiriman {{name}}. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Profil pengiriman {{name}} berhasil dihapus."
+        },
+        "tooltip": {
+            "type": "Masukkan jenis profil pengiriman, contoh: Berat, Ukuran Besar, Khusus Kargo, dll."
+        }
+    },
+    "taxRegions": {
+        "domain": "Wilayah Pajak",
+        "list": {
+            "hint": "Kelola apa yang Anda tagih kepada pelanggan Anda saat mereka berbelanja dari berbagai negara dan wilayah."
+        },
+        "delete": {
+            "confirmation": "Anda akan menghapus wilayah pajak. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Wilayah pajak berhasil dihapus."
+        },
+        "create": {
+            "header": "Buat Wilayah Pajak",
+            "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk negara tertentu.",
+            "errors": {
+                "missingProvider": "Penyedia wajib diisi saat membuat wilayah pajak.",
+                "missingCountry": "Negara wajib diisi saat membuat wilayah pajak."
+            },
+            "successToast": "Wilayah pajak berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Wilayah Pajak",
+            "hint": "Edit detail wilayah pajak.",
+            "successToast": "Wilayah pajak berhasil diperbarui."
+        },
+        "province": {
+            "header": "Provinsi",
+            "create": {
+                "header": "Buat Wilayah Pajak Provinsi",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk provinsi tertentu."
+            }
+        },
+        "provider": {
+            "header": "Penyedia Pajak"
+        },
+        "state": {
+            "header": "Negara Bagian",
+            "create": {
+                "header": "Buat Wilayah Pajak Negara Bagian",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk negara bagian tertentu."
+            }
+        },
+        "stateOrTerritory": {
+            "header": "Negara Bagian atau Teritori",
+            "create": {
+                "header": "Buat Wilayah Pajak Negara Bagian/Teritori",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk negara bagian/teritori tertentu."
+            }
+        },
+        "county": {
+            "header": "County",
+            "create": {
+                "header": "Buat Wilayah Pajak County",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk county tertentu."
+            }
+        },
+        "region": {
+            "header": "Wilayah",
+            "create": {
+                "header": "Buat Wilayah Pajak",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk wilayah tertentu."
+            }
+        },
+        "department": {
+            "header": "Departemen",
+            "create": {
+                "header": "Buat Wilayah Pajak Departemen",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk departemen tertentu."
+            }
+        },
+        "territory": {
+            "header": "Teritori",
+            "create": {
+                "header": "Buat Wilayah Pajak Teritori",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk teritori tertentu."
+            }
+        },
+        "prefecture": {
+            "header": "Prefektur",
+            "create": {
+                "header": "Buat Wilayah Pajak Prefektur",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk prefektur tertentu."
+            }
+        },
+        "district": {
+            "header": "Distrik",
+            "create": {
+                "header": "Buat Wilayah Pajak Distrik",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk distrik tertentu."
+            }
+        },
+        "governorate": {
+            "header": "Governorat",
+            "create": {
+                "header": "Buat Wilayah Pajak Governorat",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk governorat tertentu."
+            }
+        },
+        "canton": {
+            "header": "Kanton",
+            "create": {
+                "header": "Buat Wilayah Pajak Kanton",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk kanton tertentu."
+            }
+        },
+        "emirate": {
+            "header": "Emirat",
+            "create": {
+                "header": "Buat Wilayah Pajak Emirat",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk emirat tertentu."
+            }
+        },
+        "sublevel": {
+            "header": "Sublevel",
+            "create": {
+                "header": "Buat Wilayah Pajak Sublevel",
+                "hint": "Buat wilayah pajak baru untuk menentukan tarif pajak untuk sublevel tertentu."
+            }
+        },
+        "taxOverrides": {
+            "header": "Pengabaian",
+            "create": {
+                "header": "Buat Pengabaian",
+                "hint": "Buat tarif pajak yang mengabaikan tarif pajak default untuk kondisi yang dipilih."
+            },
+            "edit": {
+                "header": "Edit Pengabaian",
+                "hint": "Edit tarif pajak yang mengabaikan tarif pajak default untuk kondisi yang dipilih."
+            }
+        },
+        "taxRates": {
+            "create": {
+                "header": "Buat Tarif Pajak",
+                "hint": "Buat tarif pajak baru untuk menentukan tarif pajak untuk wilayah.",
+                "successToast": "Tarif pajak berhasil dibuat."
+            },
+            "edit": {
+                "header": "Edit Tarif Pajak",
+                "hint": "Edit tarif pajak untuk menentukan tarif pajak untuk wilayah.",
+                "successToast": "Tarif pajak berhasil diperbarui."
+            },
+            "delete": {
+                "confirmation": "Anda akan menghapus tarif pajak \"{{name}}\". Tindakan ini tidak dapat dibatalkan.",
+                "successToast": "Tarif pajak berhasil dihapus."
+            }
+        },
+        "fields": {
+            "isCombinable": {
+                "label": "Dapat Digabung",
+                "hint": "Apakah tarif pajak ini dapat digabungkan dengan tarif default dari wilayah pajak.",
+                "true": "Dapat Digabung",
+                "false": "Tidak Dapat Digabung"
+            },
+            "defaultTaxRate": {
+                "label": "Tarif pajak default",
+                "tooltip": "Tarif pajak default untuk wilayah ini. Contohnya adalah tarif PPN standar untuk negara atau wilayah.",
+                "action": "Buat tarif pajak default"
+            },
+            "taxRate": "Tarif pajak",
+            "taxCode": "Kode pajak",
+            "taxProvider": "Penyedia pajak",
+            "targets": {
+                "label": "Target",
+                "hint": "Pilih target yang akan diterapkan tarif pajak ini.",
+                "options": {
+                    "product": "Produk",
+                    "productCollection": "Koleksi produk",
+                    "productTag": "Tag produk",
+                    "productType": "Jenis produk",
+                    "customerGroup": "Grup pelanggan"
+                },
+                "operators": {
+                    "in": "dalam",
+                    "on": "pada",
+                    "and": "dan"
+                },
+                "placeholders": {
+                    "product": "Cari produk",
+                    "productCollection": "Cari koleksi produk",
+                    "productTag": "Cari tag produk",
+                    "productType": "Cari jenis produk",
+                    "customerGroup": "Cari grup pelanggan"
+                },
+                "tags": {
+                    "product": "Produk",
+                    "productCollection": "Koleksi produk",
+                    "productTag": "Tag produk",
+                    "productType": "Jenis produk",
+                    "customerGroup": "Grup pelanggan"
+                },
+                "modal": {
+                    "header": "Tambah target"
+                },
+                "values_one": "{{count}} nilai",
+                "values_other": "{{count}} nilai",
+                "numberOfTargets_one": "{{count}} target",
+                "numberOfTargets_other": "{{count}} target",
+                "additionalValues_one": "dan {{count}} nilai lainnya",
+                "additionalValues_other": "dan {{count}} nilai lainnya",
+                "action": "Tambah target"
+            },
+            "sublevels": {
+                "labels": {
+                    "province": "Provinsi",
+                    "state": "Negara Bagian",
+                    "region": "Wilayah",
+                    "stateOrTerritory": "Negara Bagian/Teritori",
+                    "department": "Departemen",
+                    "county": "County",
+                    "territory": "Teritori",
+                    "prefecture": "Prefektur",
+                    "district": "Distrik",
+                    "governorate": "Governorat",
+                    "emirate": "Emirat",
+                    "canton": "Kanton",
+                    "sublevel": "Kode sublevel"
+                },
+                "placeholders": {
+                    "province": "Pilih provinsi",
+                    "state": "Pilih negara bagian",
+                    "region": "Pilih wilayah",
+                    "stateOrTerritory": "Pilih negara bagian/teritori",
+                    "department": "Pilih departemen",
+                    "county": "Pilih county",
+                    "territory": "Pilih teritori",
+                    "prefecture": "Pilih prefektur",
+                    "district": "Pilih distrik",
+                    "governorate": "Pilih governorat",
+                    "emirate": "Pilih emirat",
+                    "canton": "Pilih kanton"
+                },
+                "tooltips": {
+                    "sublevel": "Masukkan kode ISO 3166-2 untuk wilayah pajak sublevel.",
+                    "notPartOfCountry": "{{province}} tampaknya bukan bagian dari {{country}}. Mohon periksa kembali apakah ini benar."
+                },
+                "alert": {
+                    "header": "Wilayah sublevel dinonaktifkan untuk wilayah pajak ini",
+                    "description": "Wilayah sublevel dinonaktifkan untuk wilayah ini secara default. Anda dapat mengaktifkannya untuk membuat wilayah sublevel seperti provinsi, negara bagian, atau teritori.",
+                    "action": "Aktifkan wilayah sublevel"
+                }
+            },
+            "noDefaultRate": {
+                "label": "Tidak ada tarif default",
+                "tooltip": "Wilayah pajak ini tidak memiliki tarif pajak default. Jika ada tarif standar, seperti PPN negara, tambahkan ke wilayah ini."
+            }
+        }
+    },
+    "promotions": {
+        "domain": "Promosi",
+        "sections": {
+            "details": "Detail Promosi"
+        },
+        "tabs": {
+            "template": "Jenis",
+            "details": "Detail",
+            "campaign": "Kampanye"
+        },
+        "fields": {
+            "type": "Jenis",
+            "value_type": "Jenis Nilai",
+            "value": "Nilai",
+            "campaign": "Kampanye",
+            "method": "Metode",
+            "allocation": "Alokasi",
+            "addCondition": "Tambah kondisi",
+            "clearAll": "Bersihkan semua",
+            "amount": {
+                "tooltip": "Pilih kode mata uang untuk mengaktifkan pengaturan jumlah"
+            },
+            "conditions": {
+                "rules": {
+                    "title": "Siapa yang dapat menggunakan kode ini?",
+                    "description": "Pelanggan mana yang diizinkan menggunakan kode promosi? Kode promosi dapat digunakan oleh semua pelanggan jika dibiarkan apa adanya."
+                },
+                "target-rules": {
+                    "title": "Item apa yang akan dikenakan promosi?",
+                    "description": "Promosi akan diterapkan pada item yang sesuai dengan kondisi berikut."
+                },
+                "buy-rules": {
+                    "title": "Apa yang harus ada di keranjang untuk membuka promosi?",
+                    "description": "Jika kondisi ini cocok, kami mengaktifkan promosi pada item target."
+                }
+            }
+        },
+        "tooltips": {
+            "campaignType": "Kode mata uang harus dipilih dalam promosi untuk menetapkan anggaran belanja."
+        },
+        "errors": {
+            "requiredField": "Kolom wajib diisi",
+            "promotionTabError": "Perbaiki kesalahan di Tab Promosi sebelum melanjutkan"
+        },
+        "toasts": {
+            "promotionCreateSuccess": "Promosi ({{code}}) berhasil dibuat."
+        },
+        "create": {},
+        "edit": {
+            "title": "Edit Detail Promosi",
+            "rules": {
+                "title": "Edit kondisi penggunaan"
+            },
+            "target-rules": {
+                "title": "Edit kondisi item"
+            },
+            "buy-rules": {
+                "title": "Edit aturan beli"
+            }
+        },
+        "campaign": {
+            "header": "Kampanye",
+            "edit": {
+                "header": "Edit Kampanye",
+                "successToast": "Berhasil memperbarui kampanye promosi."
+            },
+            "actions": {
+                "goToCampaign": "Pergi ke kampanye"
+            }
+        },
+        "campaign_currency": {
+            "tooltip": "Ini adalah mata uang promosi. Ubah dari tab Detail."
+        },
+        "form": {
+            "required": "Wajib",
+            "and": "DAN",
+            "selectAttribute": "Pilih Atribut",
+            "campaign": {
+                "existing": {
+                    "title": "Kampanye yang Sudah Ada",
+                    "description": "Tambah promosi ke kampanye yang sudah ada.",
+                    "placeholder": {
+                        "title": "Kampanye tidak ada",
+                        "desc": "Anda dapat membuat satu untuk melacak beberapa promosi dan menetapkan batas anggaran."
+                    }
+                },
+                "new": {
+                    "title": "Kampanye Baru",
+                    "description": "Buat kampanye baru untuk promosi ini."
+                },
+                "none": {
+                    "title": "Tanpa Kampanye",
+                    "description": "Lanjutkan tanpa mengaitkan promosi dengan kampanye"
+                }
+            },
+            "status": {
+                "label": "Status",
+                "draft": {
+                    "title": "Draf",
+                    "description": "Pelanggan belum dapat menggunakan kode"
+                },
+                "active": {
+                    "title": "Aktif",
+                    "description": "Pelanggan akan dapat menggunakan kode"
+                },
+                "inactive": {
+                    "title": "Tidak Aktif",
+                    "description": "Pelanggan tidak lagi dapat menggunakan kode"
+                }
+            },
+            "method": {
+                "label": "Metode",
+                "code": {
+                    "title": "Kode promosi",
+                    "description": "Pelanggan harus memasukkan kode ini saat checkout"
+                },
+                "automatic": {
+                    "title": "Otomatis",
+                    "description": "Pelanggan akan melihat promosi ini saat checkout"
+                }
+            },
+            "max_quantity": {
+                "title": "Kuantitas Maksimum",
+                "description": "Kuantitas maksimum item yang berlaku untuk promosi ini."
+            },
+            "type": {
+                "standard": {
+                    "title": "Standar",
+                    "description": "Promosi standar"
+                },
+                "buyget": {
+                    "title": "Beli Dapat",
+                    "description": "Promosi Beli X dapat Y"
+                }
+            },
+            "allocation": {
+                "each": {
+                    "title": "Setiap",
+                    "description": "Terapkan nilai pada setiap item"
+                },
+                "across": {
+                    "title": "Di Seluruh",
+                    "description": "Terapkan nilai di seluruh item"
+                }
+            },
+            "code": {
+                "title": "Kode",
+                "description": "Kode yang akan dimasukkan pelanggan Anda saat checkout."
+            },
+            "value": {
+                "title": "Nilai Promosi"
+            },
+            "value_type": {
+                "fixed": {
+                    "title": "Jumlah Tetap",
+                    "description": "Jumlah yang akan didiskon. contoh: 100"
+                },
+                "percentage": {
+                    "title": "Persentase",
+                    "description": "Persentase diskon dari jumlah. contoh: 8%"
+                }
+            }
+        },
+        "deleteWarning": "Anda akan menghapus promosi {{code}}. Tindakan ini tidak dapat dibatalkan.",
+        "createPromotionTitle": "Buat Promosi",
+        "type": "Jenis promosi",
+        "conditions": {
+            "add": "Tambah kondisi",
+            "list": {
+                "noRecordsMessage": "Tambah kondisi untuk membatasi item apa yang berlaku untuk promosi."
+            }
+        }
+    },
+    "campaigns": {
+        "domain": "Kampanye",
+        "details": "Detail kampanye",
+        "status": {
+            "active": "Aktif",
+            "expired": "Kedaluwarsa",
+            "scheduled": "Terjadwal"
+        },
+        "delete": {
+            "title": "Anda yakin?",
+            "description": "Anda akan menghapus kampanye '{{name}}'. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Kampanye '{{name}}' berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Kampanye",
+            "description": "Edit detail kampanye.",
+            "successToast": "Kampanye '{{name}}' berhasil diperbarui."
+        },
+        "configuration": {
+            "header": "Konfigurasi",
+            "edit": {
+                "header": "Edit Konfigurasi Kampanye",
+                "description": "Edit konfigurasi kampanye.",
+                "successToast": "Konfigurasi kampanye berhasil diperbarui."
+            }
+        },
+        "create": {
+            "title": "Buat Kampanye",
+            "description": "Buat kampanye promosi.",
+            "hint": "Buat kampanye promosi.",
+            "header": "Buat Kampanye",
+            "successToast": "Kampanye '{{name}}' berhasil dibuat."
+        },
+        "fields": {
+            "name": "Nama",
+            "identifier": "Identifier",
+            "start_date": "Tanggal mulai",
+            "end_date": "Tanggal akhir",
+            "total_spend": "Anggaran terpakai",
+            "total_used": "Anggaran digunakan",
+            "budget_limit": "Batas anggaran",
+            "campaign_id": {
+                "hint": "Hanya kampanye dengan kode mata uang yang sama dengan promosi yang ditampilkan dalam daftar ini."
+            }
+        },
+        "budget": {
+            "create": {
+                "hint": "Buat anggaran untuk kampanye.",
+                "header": "Anggaran Kampanye"
+            },
+            "details": "Anggaran kampanye",
+            "fields": {
+                "type": "Jenis",
+                "currency": "Mata uang",
+                "limit": "Batas",
+                "used": "Digunakan"
+            },
+            "type": {
+                "spend": {
+                    "title": "Belanja",
+                    "description": "Tetapkan batas pada total jumlah diskon dari semua penggunaan promosi."
+                },
+                "usage": {
+                    "title": "Penggunaan",
+                    "description": "Tetapkan batas berapa kali promosi dapat digunakan."
+                }
+            },
+            "edit": {
+                "header": "Edit Anggaran Kampanye"
+            }
+        },
+        "promotions": {
+            "remove": {
+                "title": "Hapus promosi dari kampanye",
+                "description": "Anda akan menghapus {{count}} promosi dari kampanye. Tindakan ini tidak dapat dibatalkan."
+            },
+            "alreadyAdded": "Promosi ini sudah ditambahkan ke kampanye.",
+            "alreadyAddedDiffCampaign": "Promosi ini sudah ditambahkan ke kampanye lain ({{name}}).",
+            "currencyMismatch": "Mata uang promosi dan kampanye tidak cocok",
+            "toast": {
+                "success": "Berhasil menambahkan {{count}} promosi ke kampanye"
+            },
+            "add": {
+                "list": {
+                    "noRecordsMessage": "Buat promosi terlebih dahulu."
+                }
+            },
+            "list": {
+                "noRecordsMessage": "Tidak ada promosi dalam kampanye."
+            }
+        },
+        "deleteCampaignWarning": "Anda akan menghapus kampanye {{name}}. Tindakan ini tidak dapat dibatalkan.",
+        "totalSpend": "<0>{{amount}}</0> <1>{{currency}}</1>"
+    },
+    "priceLists": {
+        "domain": "Daftar Harga",
+        "subtitle": "Buat harga penjualan atau timpa harga untuk kondisi tertentu.",
+        "delete": {
+            "confirmation": "Anda akan menghapus daftar harga \"{{title}}\". Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Daftar harga \"{{title}}\" berhasil dihapus."
+        },
+        "create": {
+            "header": "Buat Daftar Harga",
+            "subheader": "Buat daftar harga baru untuk mengelola harga produk Anda.",
+            "tabs": {
+                "details": "Detail",
+                "products": "Produk",
+                "prices": "Harga"
+            },
+            "successToast": "Daftar harga {{title}} berhasil dibuat.",
+            "products": {
+                "list": {
+                    "noRecordsMessage": "Buat produk terlebih dahulu."
+                }
+            }
+        },
+        "edit": {
+            "header": "Edit Daftar Harga",
+            "successToast": "Daftar harga {{title}} berhasil diperbarui."
+        },
+        "configuration": {
+            "header": "Konfigurasi",
+            "edit": {
+                "header": "Edit Konfigurasi Daftar Harga",
+                "description": "Edit konfigurasi daftar harga.",
+                "successToast": "Konfigurasi daftar harga berhasil diperbarui."
+            }
+        },
+        "products": {
+            "header": "Produk",
+            "actions": {
+                "addProducts": "Tambah produk",
+                "editPrices": "Edit harga"
+            },
+            "delete": {
+                "confirmation_one": "Anda akan menghapus harga untuk {{count}} produk dalam daftar harga. Tindakan ini tidak dapat dibatalkan.",
+                "confirmation_other": "Anda akan menghapus harga untuk {{count}} produk dalam daftar harga. Tindakan ini tidak dapat dibatalkan.",
+                "successToast_one": "Berhasil menghapus harga untuk {{count}} produk.",
+                "successToast_other": "Berhasil menghapus harga untuk {{count}} produk."
+            },
+            "add": {
+                "successToast": "Harga berhasil ditambahkan ke daftar harga."
+            },
+            "edit": {
+                "successToast": "Harga berhasil diperbarui."
+            }
+        },
+        "fields": {
+            "priceOverrides": {
+                "label": "Timpa harga",
+                "header": "Timpa Harga"
+            },
+            "status": {
+                "label": "Status",
+                "options": {
+                    "active": "Aktif",
+                    "draft": "Draf",
+                    "expired": "Kedaluwarsa",
+                    "scheduled": "Terjadwal"
+                }
+            },
+            "type": {
+                "label": "Jenis",
+                "hint": "Pilih jenis daftar harga yang ingin Anda buat.",
+                "options": {
+                    "sale": {
+                        "label": "Obral",
+                        "description": "Harga obral adalah perubahan harga sementara untuk produk."
+                    },
+                    "override": {
+                        "label": "Timpa",
+                        "description": "Timpa biasanya digunakan untuk membuat harga khusus pelanggan."
+                    }
+                }
+            },
+            "startsAt": {
+                "label": "Daftar harga memiliki tanggal mulai?",
+                "hint": "Jadwalkan daftar harga untuk aktif di masa mendatang."
+            },
+            "endsAt": {
+                "label": "Daftar harga memiliki tanggal kedaluwarsa?",
+                "hint": "Jadwalkan daftar harga untuk dinonaktifkan di masa mendatang."
+            },
+            "customerAvailability": {
+                "header": "Pilih grup pelanggan",
+                "label": "Ketersediaan pelanggan",
+                "hint": "Pilih grup pelanggan mana yang harus diterapkan daftar harga.",
+                "placeholder": "Cari grup pelanggan",
+                "attribute": "Grup pelanggan"
+            }
+        }
+    },
+    "profile": {
+        "domain": "Profil",
+        "manageYourProfileDetails": "Kelola detail profil Anda.",
+        "fields": {
+            "languageLabel": "Bahasa",
+            "usageInsightsLabel": "Wawasan penggunaan"
+        },
+        "edit": {
+            "header": "Edit Profil",
+            "languageHint": "Bahasa yang ingin Anda gunakan di dasbor admin. Ini tidak mengubah bahasa toko Anda.",
+            "languagePlaceholder": "Pilih bahasa",
+            "usageInsightsHint": "Bagikan wawasan penggunaan dan bantu kami meningkatkan Medusa. Anda dapat membaca lebih lanjut tentang apa yang kami kumpulkan dan bagaimana kami menggunakannya di <0>dokumentasi</0> kami."
+        },
+        "toast": {
+            "edit": "Perubahan profil tersimpan"
+        }
+    },
+    "users": {
+        "domain": "Pengguna",
+        "editUser": "Edit Pengguna",
+        "inviteUser": "Undang Pengguna",
+        "inviteUserHint": "Undang pengguna baru ke toko Anda.",
+        "sendInvite": "Kirim undangan",
+        "pendingInvites": "Undangan Tertunda",
+        "deleteInviteWarning": "Anda akan menghapus undangan untuk {{email}}. Tindakan ini tidak dapat dibatalkan.",
+        "resendInvite": "Kirim ulang undangan",
+        "copyInviteLink": "Salin tautan undangan",
+        "expiredOnDate": "Kedaluwarsa pada {{date}}",
+        "validFromUntil": "Berlaku dari <0>{{from}}</0> - <1>{{until}}</1>",
+        "acceptedOnDate": "Diterima pada {{date}}",
+        "inviteStatus": {
+            "accepted": "Diterima",
+            "pending": "Tertunda",
+            "expired": "Kedaluwarsa"
+        },
+        "roles": {
+            "admin": "Admin",
+            "developer": "Pengembang",
+            "member": "Anggota"
+        },
+        "list": {
+            "empty": {
+                "heading": "Tidak ada pengguna ditemukan",
+                "description": "Setelah pengguna diundang, mereka akan muncul di sini."
+            },
+            "filtered": {
+                "heading": "Tidak ada hasil",
+                "description": "Tidak ada pengguna yang cocok dengan kriteria filter saat ini."
+            }
+        },
+        "deleteUserWarning": "Anda akan menghapus pengguna {{name}}. Tindakan ini tidak dapat dibatalkan.",
+        "deleteUserSuccess": "Pengguna {{name}} berhasil dihapus",
+        "invite": "Undang"
+    },
+    "store": {
+        "domain": "Toko",
+        "manageYourStoresDetails": "Kelola detail toko Anda",
+        "editStore": "Edit toko",
+        "defaultCurrency": "Mata uang default",
+        "defaultRegion": "Wilayah default",
+        "defaultSalesChannel": "Saluran penjualan default",
+        "defaultLocation": "Lokasi default",
+        "swapLinkTemplate": "Template tautan swap",
+        "paymentLinkTemplate": "Template tautan pembayaran",
+        "inviteLinkTemplate": "Template tautan undangan",
+        "currencies": "Mata uang",
+        "addCurrencies": "Tambah mata uang",
+        "enableTaxInclusivePricing": "Aktifkan harga termasuk pajak",
+        "disableTaxInclusivePricing": "Nonaktifkan harga termasuk pajak",
+        "removeCurrencyWarning_one": "Anda akan menghapus {{count}} mata uang dari toko Anda. Pastikan Anda telah menghapus semua harga menggunakan mata uang tersebut sebelum melanjutkan.",
+        "removeCurrencyWarning_other": "Anda akan menghapus {{count}} mata uang dari toko Anda. Pastikan Anda telah menghapus semua harga menggunakan mata uang tersebut sebelum melanjutkan.",
+        "currencyAlreadyAdded": "Mata uang sudah ditambahkan ke toko Anda.",
+        "edit": {
+            "header": "Edit Toko"
+        },
+        "toast": {
+            "update": "Toko berhasil diperbarui",
+            "currenciesUpdated": "Mata uang berhasil diperbarui",
+            "currenciesRemoved": "Mata uang berhasil dihapus dari toko",
+            "updatedTaxInclusivitySuccessfully": "Harga termasuk pajak berhasil diperbarui"
+        }
+    },
+    "regions": {
+        "domain": "Wilayah",
+        "subtitle": "Wilayah adalah area tempat Anda menjual produk. Ini dapat mencakup beberapa negara, dan memiliki tarif pajak, penyedia, dan mata uang yang berbeda.",
+        "createRegion": "Buat Wilayah",
+        "createRegionHint": "Kelola tarif pajak dan penyedia untuk sekumpulan negara.",
+        "addCountries": "Tambah negara",
+        "editRegion": "Edit Wilayah",
+        "countriesHint": "Tambah negara yang termasuk dalam wilayah ini.",
+        "deleteRegionWarning": "Anda akan menghapus wilayah {{name}}. Tindakan ini tidak dapat dibatalkan.",
+        "removeCountriesWarning_one": "Anda akan menghapus {{count}} negara dari wilayah ini. Tindakan ini tidak dapat dibatalkan.",
+        "removeCountriesWarning_other": "Anda akan menghapus {{count}} negara dari wilayah ini. Tindakan ini tidak dapat dibatalkan.",
+        "removeCountryWarning": "Anda akan menghapus negara {{name}} dari wilayah ini. Tindakan ini tidak dapat dibatalkan.",
+        "automaticTaxesHint": "Jika diaktifkan, pajak hanya akan dihitung saat checkout berdasarkan alamat pengiriman.",
+        "taxInclusiveHint": "Jika diaktifkan, harga di wilayah ini sudah termasuk pajak.",
+        "providersHint": "Tambah penyedia pembayaran mana yang tersedia di wilayah ini.",
+        "shippingOptions": "Opsi Pengiriman",
+        "deleteShippingOptionWarning": "Anda akan menghapus opsi pengiriman {{name}}. Tindakan ini tidak dapat dibatalkan.",
+        "return": "Kembalikan",
+        "outbound": "Keluar",
+        "priceType": "Jenis Harga",
+        "flatRate": "Tarif Tetap",
+        "calculated": "Dihitung",
+        "list": {
+            "noRecordsMessage": "Buat wilayah untuk area tempat Anda berjualan."
+        },
+        "toast": {
+            "delete": "Wilayah berhasil dihapus",
+            "edit": "Edit wilayah tersimpan",
+            "create": "Wilayah berhasil dibuat",
+            "countries": "Negara wilayah berhasil diperbarui"
+        },
+        "shippingOption": {
+            "createShippingOption": "Buat Opsi Pengiriman",
+            "createShippingOptionHint": "Buat opsi pengiriman baru untuk wilayah.",
+            "editShippingOption": "Edit Opsi Pengiriman",
+            "fulfillmentMethod": "Metode Pemenuhan",
+            "type": {
+                "outbound": "Keluar",
+                "outboundHint": "Gunakan ini jika Anda membuat opsi pengiriman untuk mengirim produk ke pelanggan.",
+                "return": "Kembalikan",
+                "returnHint": "Gunakan ini jika Anda membuat opsi pengiriman agar pelanggan dapat mengembalikan produk kepada Anda."
+            },
+            "priceType": {
+                "label": "Jenis Harga",
+                "flatRate": "Tarif tetap",
+                "calculated": "Dihitung"
+            },
+            "availability": {
+                "adminOnly": "Hanya admin",
+                "adminOnlyHint": "Jika diaktifkan, opsi pengiriman hanya akan tersedia di dasbor admin, dan tidak di etalase."
+            },
+            "taxInclusiveHint": "Jika diaktifkan, harga opsi pengiriman akan termasuk pajak.",
+            "requirements": {
+                "label": "Persyaratan",
+                "hint": "Tentukan persyaratan untuk opsi pengiriman."
+            }
+        }
+    },
+    "taxes": {
+        "domain": "Wilayah Pajak",
+        "domainDescription": "Kelola wilayah pajak Anda",
+        "countries": {
+            "taxCountriesHint": "Pengaturan pajak berlaku untuk negara yang terdaftar."
+        },
+        "settings": {
+            "editTaxSettings": "Edit Pengaturan Pajak",
+            "taxProviderLabel": "Penyedia pajak",
+            "systemTaxProviderLabel": "Penyedia Pajak Sistem",
+            "calculateTaxesAutomaticallyLabel": "Hitung pajak secara otomatis",
+            "calculateTaxesAutomaticallyHint": "Jika diaktifkan, tarif pajak akan dihitung secara otomatis dan diterapkan pada keranjang. Jika dinonaktifkan, pajak harus dihitung secara manual saat checkout. Pajak manual disarankan untuk digunakan dengan penyedia pajak pihak ketiga.",
+            "applyTaxesOnGiftCardsLabel": "Terapkan pajak pada kartu hadiah",
+            "applyTaxesOnGiftCardsHint": "Jika diaktifkan, pajak akan diterapkan pada kartu hadiah saat checkout. Di beberapa negara, peraturan pajak mewajibkan penerapan pajak pada kartu hadiah saat pembelian.",
+            "defaultTaxRateLabel": "Tarif pajak default",
+            "defaultTaxCodeLabel": "Kode pajak default"
+        },
+        "defaultRate": {
+            "sectionTitle": "Tarif Pajak Default"
+        },
+        "taxRate": {
+            "sectionTitle": "Tarif Pajak",
+            "createTaxRate": "Buat Tarif Pajak",
+            "createTaxRateHint": "Buat tarif pajak baru untuk wilayah.",
+            "deleteRateDescription": "Anda akan menghapus tarif pajak {{name}}. Tindakan ini tidak dapat dibatalkan.",
+            "editRateAction": "Edit tarif",
+            "editOverridesAction": "Edit pengabaian",
+            "editOverridesTitle": "Edit Pengabaian Tarif Pajak",
+            "editOverridesHint": "Tentukan pengabaian untuk tarif pajak.",
+            "deleteTaxRateWarning": "Anda akan menghapus tarif pajak {{name}}. Tindakan ini tidak dapat dibatalkan.",
+            "productOverridesLabel": "Pengabaian produk",
+            "productOverridesHint": "Tentukan pengabaian produk untuk tarif pajak.",
+            "addProductOverridesAction": "Tambah pengabaian produk",
+            "productTypeOverridesLabel": "Pengabaian jenis produk",
+            "productTypeOverridesHint": "Tentukan pengabaian jenis produk untuk tarif pajak.",
+            "addProductTypeOverridesAction": "Tambah pengabaian jenis produk",
+            "shippingOptionOverridesLabel": "Pengabaian opsi pengiriman",
+            "shippingOptionOverridesHint": "Tentukan pengabaian opsi pengiriman untuk tarif pajak.",
+            "addShippingOptionOverridesAction": "Tambah pengabaian opsi pengiriman",
+            "productOverridesHeader": "Produk",
+            "productTypeOverridesHeader": "Jenis Produk",
+            "shippingOptionOverridesHeader": "Opsi Pengiriman"
+        }
+    },
+    "locations": {
+        "domain": "Lokasi",
+        "editLocation": "Edit lokasi",
+        "addSalesChannels": "Tambah saluran penjualan",
+        "noLocationsFound": "Tidak ada lokasi ditemukan",
+        "selectLocations": "Pilih lokasi yang menyimpan item.",
+        "deleteLocationWarning": "Anda akan menghapus lokasi {{name}}. Tindakan ini tidak dapat dibatalkan.",
+        "removeSalesChannelsWarning_one": "Anda akan menghapus {{count}} saluran penjualan dari lokasi.",
+        "removeSalesChannelsWarning_other": "Anda akan menghapus {{count}} saluran penjualan dari lokasi.",
+        "toast": {
+            "create": "Lokasi berhasil dibuat",
+            "update": "Lokasi berhasil diperbarui",
+            "removeChannel": "Saluran penjualan berhasil dihapus"
+        }
+    },
+    "reservations": {
+        "domain": "Reservasi",
+        "subtitle": "Kelola kuantitas item inventaris yang dipesan.",
+        "deleteWarning": "Anda akan menghapus reservasi. Tindakan ini tidak dapat dibatalkan."
+    },
+    "salesChannels": {
+        "domain": "Saluran Penjualan",
+        "subtitle": "Kelola saluran online dan offline tempat Anda menjual produk.",
+        "list": {
+            "empty": {
+                "heading": "Tidak ada saluran penjualan ditemukan",
+                "description": "Setelah saluran penjualan dibuat, akan muncul di sini."
+            },
+            "filtered": {
+                "heading": "Tidak ada hasil",
+                "description": "Tidak ada saluran penjualan yang cocok dengan kriteria filter saat ini."
+            }
+        },
+        "createSalesChannel": "Buat Saluran Penjualan",
+        "createSalesChannelHint": "Buat saluran penjualan baru untuk menjual produk Anda.",
+        "enabledHint": "Tentukan apakah saluran penjualan diaktifkan.",
+        "removeProductsWarning_one": "Anda akan menghapus {{count}} produk dari {{sales_channel}}.",
+        "removeProductsWarning_other": "Anda akan menghapus {{count}} produk dari {{sales_channel}}.",
+        "addProducts": "Tambah Produk",
+        "editSalesChannel": "Edit saluran penjualan",
+        "productAlreadyAdded": "Produk sudah ditambahkan ke saluran penjualan.",
+        "deleteSalesChannelWarning": "Anda akan menghapus saluran penjualan {{name}}. Tindakan ini tidak dapat dibatalkan.",
+        "toast": {
+            "create": "Saluran penjualan berhasil dibuat",
+            "update": "Saluran penjualan berhasil diperbarui",
+            "delete": "Saluran penjualan berhasil dihapus"
+        },
+        "tooltip": {
+            "cannotDeleteDefault": "Tidak dapat menghapus saluran penjualan default"
+        },
+        "products": {
+            "list": {
+                "noRecordsMessage": "Tidak ada produk di saluran penjualan."
+            },
+            "add": {
+                "list": {
+                    "noRecordsMessage": "Buat produk terlebih dahulu."
+                }
+            }
+        }
+    },
+    "apiKeyManagement": {
+        "domain": {
+            "publishable": "Kunci API yang Dapat Dipublikasikan",
+            "secret": "Kunci API Rahasia"
+        },
+        "subtitle": {
+            "publishable": "Kelola kunci API yang digunakan di etalase untuk membatasi cakupan permintaan ke saluran penjualan tertentu.",
+            "secret": "Kelola kunci API yang digunakan untuk mengautentikasi pengguna admin di aplikasi admin."
+        },
+        "status": {
+            "active": "Aktif",
+            "revoked": "Dicabut"
+        },
+        "type": {
+            "publishable": "Dapat Dipublikasikan",
+            "secret": "Rahasia"
+        },
+        "create": {
+            "createPublishableHeader": "Buat Kunci API yang Dapat Dipublikasikan",
+            "createPublishableHint": "Buat kunci API yang dapat dipublikasikan baru untuk membatasi cakupan permintaan ke saluran penjualan tertentu.",
+            "createSecretHeader": "Buat Kunci API Rahasia",
+            "createSecretHint": "Buat kunci API rahasia baru untuk mengakses Medusa API sebagai pengguna admin terautentikasi.",
+            "secretKeyCreatedHeader": "Kunci Rahasia Dibuat",
+            "secretKeyCreatedHint": "Kunci rahasia baru Anda telah dibuat. Salin dan simpan dengan aman sekarang. Ini adalah satu-satunya saat akan ditampilkan.",
+            "copySecretTokenSuccess": "Kunci rahasia berhasil disalin ke papan klip.",
+            "copySecretTokenFailure": "Gagal menyalin kunci rahasia ke papan klip.",
+            "successToast": "Kunci API berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Kunci API",
+            "description": "Edit judul kunci API.",
+            "successToast": "Kunci API {{title}} berhasil diperbarui."
+        },
+        "salesChannels": {
+            "title": "Tambah Saluran Penjualan",
+            "description": "Tambah saluran penjualan yang harus dibatasi oleh kunci API.",
+            "successToast_one": "{{count}} saluran penjualan berhasil ditambahkan ke kunci API.",
+            "successToast_other": "{{count}} saluran penjualan berhasil ditambahkan ke kunci API.",
+            "alreadyAddedTooltip": "Saluran penjualan sudah ditambahkan ke kunci API.",
+            "list": {
+                "noRecordsMessage": "Tidak ada saluran penjualan dalam cakupan kunci API yang dapat dipublikasikan."
+            }
+        },
+        "delete": {
+            "warning": "Anda akan menghapus kunci API {{title}}. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Kunci API {{title}} berhasil dihapus."
+        },
+        "revoke": {
+            "warning": "Anda akan mencabut kunci API {{title}}. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Kunci API {{title}} berhasil dicabut."
+        },
+        "addSalesChannels": {
+            "list": {
+                "noRecordsMessage": "Buat saluran penjualan terlebih dahulu."
+            }
+        },
+        "removeSalesChannel": {
+            "warning": "Anda akan menghapus saluran penjualan {{name}} dari kunci API. Tindakan ini tidak dapat dibatalkan.",
+            "warningBatch_one": "Anda akan menghapus {{count}} saluran penjualan dari kunci API. Tindakan ini tidak dapat dibatalkan.",
+            "warningBatch_other": "Anda akan menghapus {{count}} saluran penjualan dari kunci API. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Saluran penjualan berhasil dihapus dari kunci API.",
+            "successToastBatch_one": "{{count}} saluran penjualan berhasil dihapus dari kunci API.",
+            "successToastBatch_other": "{{count}} saluran penjualan berhasil dihapus dari kunci API."
+        },
+        "actions": {
+            "revoke": "Cabut kunci API",
+            "copy": "Salin kunci API",
+            "copySuccessToast": "Kunci API berhasil disalin ke papan klip."
+        },
+        "table": {
+            "lastUsedAtHeader": "Terakhir Digunakan Pada",
+            "createdAtHeader": "Dicabut Pada"
+        },
+        "fields": {
+            "lastUsedAtLabel": "Terakhir digunakan pada",
+            "revokedByLabel": "Dicabut oleh",
+            "revokedAtLabel": "Dicabut pada",
+            "createdByLabel": "Dibuat oleh"
+        }
+    },
+    "returnReasons": {
+        "domain": "Alasan Pengembalian",
+        "subtitle": "Kelola alasan untuk item yang dikembalikan.",
+        "calloutHint": "Kelola alasan untuk mengkategorikan pengembalian.",
+        "editReason": "Edit Alasan Pengembalian",
+        "create": {
+            "header": "Tambah Alasan Pengembalian",
+            "subtitle": "Tentukan alasan paling umum untuk pengembalian.",
+            "hint": "Buat alasan pengembalian baru untuk mengkategorikan pengembalian.",
+            "successToast": "Alasan pengembalian {{label}} berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Alasan Pengembalian",
+            "subtitle": "Edit nilai alasan pengembalian.",
+            "successToast": "Alasan pengembalian {{label}} berhasil diperbarui."
+        },
+        "delete": {
+            "confirmation": "Anda akan menghapus alasan pengembalian \"{{label}}\". Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Alasan pengembalian \"{{label}}\" berhasil dihapus."
+        },
+        "fields": {
+            "value": {
+                "label": "Nilai",
+                "placeholder": "salah_ukuran",
+                "tooltip": "Nilai harus menjadi pengenal unik untuk alasan pengembalian."
+            },
+            "label": {
+                "label": "Label",
+                "placeholder": "Ukuran salah"
+            },
+            "description": {
+                "label": "Deskripsi",
+                "placeholder": "Pelanggan menerima ukuran yang salah"
+            }
+        }
+    },
+    "login": {
+        "forgotPassword": "Lupa kata sandi? - <0>Setel ulang</0>",
+        "title": "Selamat datang di Medusa",
+        "hint": "Masuk untuk mengakses area akun"
+    },
+    "invite": {
+        "title": "Selamat datang di Medusa",
+        "hint": "Buat akun Anda di bawah",
+        "backToLogin": "Kembali ke login",
+        "createAccount": "Buat akun",
+        "alreadyHaveAccount": "Sudah punya akun? - <0>Masuk</0>",
+        "emailTooltip": "Alamat email Anda tidak dapat diubah. Jika Anda ingin menggunakan email lain, undangan baru harus dikirim.",
+        "invalidInvite": "Undangan tidak valid atau sudah kedaluwarsa.",
+        "successTitle": "Akun Anda telah terdaftar",
+        "successHint": "Mulai gunakan Medusa Admin sekarang juga.",
+        "successAction": "Mulai Medusa Admin",
+        "invalidTokenTitle": "Token undangan Anda tidak valid",
+        "invalidTokenHint": "Coba minta tautan undangan baru.",
+        "passwordMismatch": "Kata sandi tidak cocok",
+        "toast": {
+            "accepted": "Undangan berhasil diterima"
+        }
+    },
+    "resetPassword": {
+        "title": "Setel ulang kata sandi",
+        "hint": "Masukkan email Anda di bawah, dan kami akan mengirimkan instruksi tentang cara mengatur ulang kata sandi Anda.",
+        "email": "Email",
+        "sendResetInstructions": "Kirim instruksi setel ulang",
+        "backToLogin": "<0>Kembali ke login</0>",
+        "newPasswordHint": "Pilih kata sandi baru di bawah.",
+        "invalidTokenTitle": "Token setel ulang Anda tidak valid",
+        "invalidTokenHint": "Coba setel ulang kata sandi Anda lagi.",
+        "expiredTokenTitle": "Token setel ulang Anda telah kedaluwarsa",
+        "goToResetPassword": "Pergi ke Setel Ulang Kata Sandi",
+        "resetPassword": "Setel ulang kata sandi",
+        "newPassword": "Kata sandi baru",
+        "repeatNewPassword": "Ulangi kata sandi baru",
+        "tokenExpiresIn": "Token kedaluwarsa dalam <0>{{time}}</0> menit",
+        "successfulRequestTitle": "Berhasil mengirim email kepada Anda",
+        "successfulRequest": "Kami telah mengirimkan email yang dapat Anda gunakan untuk mengatur ulang kata sandi Anda. Periksa folder spam Anda jika Anda belum menerimanya setelah beberapa menit.",
+        "successfulResetTitle": "Setel ulang kata sandi berhasil",
+        "successfulReset": "Silakan masuk di halaman login.",
+        "passwordMismatch": "Kata sandi tidak cocok",
+        "invalidLinkTitle": "Tautan setel ulang Anda tidak valid",
+        "invalidLinkHint": "Coba setel ulang kata sandi Anda lagi."
+    },
+    "workflowExecutions": {
+        "domain": "Alur Kerja",
+        "subtitle": "Lihat dan pantau eksekusi alur kerja di aplikasi Medusa Anda.",
+        "transactionIdLabel": "ID Transaksi",
+        "workflowIdLabel": "ID Alur Kerja",
+        "progressLabel": "Kemajuan",
+        "stepsCompletedLabel_one": "{{completed}} dari {{count}} langkah",
+        "stepsCompletedLabel_other": "{{completed}} dari {{count}} langkah",
+        "list": {
+            "noRecordsMessage": "Belum ada alur kerja yang dieksekusi."
+        },
+        "history": {
+            "sectionTitle": "Riwayat",
+            "runningState": "Berjalan...",
+            "awaitingState": "Menunggu",
+            "failedState": "Gagal",
+            "skippedState": "Dilewati",
+            "skippedFailureState": "Dilewati (Gagal)",
+            "definitionLabel": "Definisi",
+            "outputLabel": "Output",
+            "compensateInputLabel": "Input kompensasi",
+            "revertedLabel": "Dikembalikan",
+            "errorLabel": "Kesalahan"
+        },
+        "state": {
+            "done": "Selesai",
+            "failed": "Gagal",
+            "reverted": "Dikembalikan",
+            "invoking": "Memanggil",
+            "compensating": "Mengkompensasi",
+            "notStarted": "Belum dimulai"
+        },
+        "transaction": {
+            "state": {
+                "waitingToCompensate": "Menunggu kompensasi"
+            }
+        },
+        "step": {
+            "state": {
+                "skipped": "Dilewati",
+                "skippedFailure": "Dilewati (Gagal)",
+                "dormant": "Dorman",
+                "timeout": "Waktu habis"
+            }
+        }
+    },
+    "productTypes": {
+        "domain": "Jenis Produk",
+        "subtitle": "Atur produk Anda ke dalam jenis.",
+        "create": {
+            "header": "Buat Jenis Produk",
+            "hint": "Buat jenis produk baru untuk mengkategorikan produk Anda.",
+            "successToast": "Jenis produk {{value}} berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Jenis Produk",
+            "successToast": "Jenis produk {{value}} berhasil diperbarui."
+        },
+        "delete": {
+            "confirmation": "Anda akan menghapus jenis produk \"{{value}}\". Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Jenis produk \"{{value}}\" berhasil dihapus."
+        },
+        "fields": {
+            "value": "Nilai"
+        }
+    },
+    "productTags": {
+        "domain": "Tag Produk",
+        "create": {
+            "header": "Buat Tag Produk",
+            "subtitle": "Buat tag produk baru untuk mengkategorikan produk Anda.",
+            "successToast": "Tag produk {{value}} berhasil dibuat."
+        },
+        "edit": {
+            "header": "Edit Tag Produk",
+            "subtitle": "Edit nilai tag produk.",
+            "successToast": "Tag produk {{value}} berhasil diperbarui."
+        },
+        "delete": {
+            "confirmation": "Anda akan menghapus tag produk {{value}}. Tindakan ini tidak dapat dibatalkan.",
+            "successToast": "Tag produk {{value}} berhasil dihapus."
+        },
+        "fields": {
+            "value": "Nilai"
+        }
+    },
+    "notifications": {
+        "domain": "Notifikasi",
+        "emptyState": {
+            "title": "Tidak ada notifikasi",
+            "description": "Anda belum memiliki notifikasi saat ini, tetapi setelah ada, akan muncul di sini."
+        },
+        "accessibility": {
+            "description": "Notifikasi tentang aktivitas Medusa akan dicantumkan di sini."
+        }
+    },
+    "errors": {
+        "serverError": "Kesalahan server - Coba lagi nanti.",
+        "invalidCredentials": "Email atau kata sandi salah"
+    },
+    "statuses": {
+        "scheduled": "Terjadwal",
+        "expired": "Kedaluwarsa",
+        "active": "Aktif",
+        "inactive": "Tidak aktif",
+        "draft": "Draf",
+        "enabled": "Diaktifkan",
+        "disabled": "Dinonaktifkan"
+    },
+    "labels": {
+        "productVariant": "Varian Produk",
+        "prices": "Harga",
+        "available": "Tersedia",
+        "inStock": "Stok tersedia",
+        "added": "Ditambahkan",
+        "removed": "Dihapus",
+        "from": "Dari",
+        "to": "Kepada",
+        "beaware": "Perhatikan",
+        "loading": "Memuat"
+    },
+    "fields": {
+        "amount": "Jumlah",
+        "refundAmount": "Jumlah pengembalian dana",
+        "name": "Nama",
+        "default": "Default",
+        "lastName": "Nama Belakang",
+        "firstName": "Nama Depan",
+        "title": "Judul",
+        "customTitle": "Judul kustom",
+        "manageInventory": "Kelola inventaris",
+        "inventoryKit": "Memiliki kit inventaris",
+        "inventoryItems": "Item inventaris",
+        "inventoryItem": "Item inventaris",
+        "requiredQuantity": "Kuantitas wajib",
+        "description": "Deskripsi",
+        "email": "Email",
+        "password": "Kata sandi",
+        "repeatPassword": "Ulangi Kata Sandi",
+        "confirmPassword": "Konfirmasi Kata Sandi",
+        "newPassword": "Kata Sandi Baru",
+        "repeatNewPassword": "Ulangi Kata Sandi Baru",
+        "categories": "Kategori",
+        "shippingMethod": "Metode pengiriman",
+        "configurations": "Konfigurasi",
+        "conditions": "Kondisi",
+        "category": "Kategori",
+        "collection": "Koleksi",
+        "discountable": "Dapat diskon",
+        "handle": "Handle",
+        "subtitle": "Subjudul",
+        "by": "Oleh",
+        "item": "Item",
+        "qty": "kuantitas.",
+        "limit": "Batas",
+        "tags": "Tag",
+        "type": "Jenis",
+        "reason": "Alasan",
+        "none": "tidak ada",
+        "all": "semua",
+        "search": "Cari",
+        "percentage": "Persentase",
+        "sales_channels": "Saluran Penjualan",
+        "customer_groups": "Grup Pelanggan",
+        "product_tags": "Tag Produk",
+        "product_types": "Jenis Produk",
+        "product_collections": "Koleksi Produk",
+        "status": "Status",
+        "code": "Kode",
+        "value": "Nilai",
+        "disabled": "Dinonaktifkan",
+        "dynamic": "Dinamis",
+        "normal": "Normal",
+        "years": "Tahun",
+        "months": "Bulan",
+        "days": "Hari",
+        "hours": "Jam",
+        "minutes": "Menit",
+        "totalRedemptions": "Total Penukaran",
+        "countries": "Negara",
+        "paymentProviders": "Penyedia Pembayaran",
+        "refundReason": "Alasan Pengembalian Dana",
+        "fulfillmentProviders": "Penyedia Pemenuhan",
+        "fulfillmentProvider": "Penyedia Pemenuhan",
+        "providers": "Penyedia",
+        "availability": "Ketersediaan",
+        "inventory": "Inventaris",
+        "optional": "Opsional",
+        "note": "Catatan",
+        "automaticTaxes": "Pajak Otomatis",
+        "taxInclusivePricing": "Harga termasuk pajak",
+        "currency": "Mata uang",
+        "address": "Alamat",
+        "address2": "Apartemen, suite, dll.",
+        "city": "Kota",
+        "postalCode": "Kode Pos",
+        "country": "Negara",
+        "state": "Negara Bagian",
+        "province": "Provinsi",
+        "company": "Perusahaan",
+        "phone": "Telepon",
+        "metadata": "Metadata",
+        "selectCountry": "Pilih negara",
+        "products": "Produk",
+        "variants": "Varian",
+        "orders": "Pesanan",
+        "account": "Akun",
+        "total": "Total Pesanan",
+        "paidTotal": "Total diambil",
+        "totalExclTax": "Total tidak termasuk pajak",
+        "subtotal": "Subtotal",
+        "shipping": "Pengiriman",
+        "outboundShipping": "Pengiriman Keluar",
+        "returnShipping": "Pengiriman Pengembalian",
+        "tax": "Pajak",
+        "created": "Dibuat",
+        "key": "Kunci",
+        "customer": "Pelanggan",
+        "date": "Tanggal",
+        "order": "Pesanan",
+        "fulfillment": "Pemenuhan",
+        "provider": "Penyedia",
+        "payment": "Pembayaran",
+        "items": "Item",
+        "salesChannel": "Saluran Penjualan",
+        "region": "Wilayah",
+        "discount": "Diskon",
+        "role": "Peran",
+        "sent": "Terkirim",
+        "salesChannels": "Saluran Penjualan",
+        "product": "Produk",
+        "createdAt": "Dibuat pada",
+        "updatedAt": "Diperbarui pada",
+        "revokedAt": "Dicabut pada",
+        "true": "Benar",
+        "false": "Salah",
+        "giftCard": "Kartu Hadiah",
+        "tag": "Tag",
+        "dateIssued": "Tanggal diterbitkan",
+        "issuedDate": "Tanggal diterbitkan",
+        "expiryDate": "Tanggal kedaluwarsa",
+        "price": "Harga",
+        "priceTemplate": "Harga {{regionOrCurrency}}",
+        "height": "Tinggi",
+        "width": "Lebar",
+        "length": "Panjang",
+        "weight": "Berat",
+        "midCode": "Kode MID",
+        "hsCode": "Kode HS",
+        "ean": "EAN",
+        "upc": "UPC",
+        "inventoryQuantity": "Kuantitas inventaris",
+        "barcode": "Kode batang",
+        "countryOfOrigin": "Negara asal",
+        "material": "Bahan",
+        "thumbnail": "Thumbnail",
+        "sku": "SKU",
+        "managedInventory": "Inventaris dikelola",
+        "allowBackorder": "Izinkan pesanan kembali",
+        "inStock": "Stok tersedia",
+        "location": "Lokasi",
+        "quantity": "Kuantitas",
+        "variant": "Varian",
+        "id": "ID",
+        "parent": "Induk",
+        "minSubtotal": "Subtotal Min.",
+        "maxSubtotal": "Subtotal Maks.",
+        "shippingProfile": "Profil Pengiriman",
+        "summary": "Ringkasan",
+        "details": "Detail",
+        "label": "Label",
+        "rate": "Tarif",
+        "requiresShipping": "Membutuhkan pengiriman",
+        "unitPrice": "Harga satuan",
+        "startDate": "Tanggal mulai",
+        "endDate": "Tanggal akhir",
+        "draft": "Draf",
+        "values": "Nilai"
+    },
+    "dateTime": {
+        "years_one": "Tahun",
+        "years_other": "Tahun",
+        "months_one": "Bulan",
+        "months_other": "Bulan",
+        "weeks_one": "Minggu",
+        "weeks_other": "Minggu",
+        "days_one": "Hari",
+        "days_other": "Hari",
+        "hours_one": "Jam",
+        "hours_other": "Jam",
+        "minutes_one": "Menit",
+        "minutes_other": "Menit",
+        "seconds_one": "Detik",
+        "seconds_other": "Detik"
+    }
+}

--- a/packages/admin/dashboard/src/i18n/translations/index.ts
+++ b/packages/admin/dashboard/src/i18n/translations/index.ts
@@ -26,7 +26,7 @@ import vi from "./vi.json"
 import ko from "./ko.json"
 import nl from "./nl.json"
 import bs from "./bs.json"
-
+import id from "./id.json"
 export default {
   bs: {
     translation: bs,
@@ -111,5 +111,8 @@ export default {
   },
   nl: {
     translation: nl,
+  },
+  id: {
+    translation: id,
   },
 }


### PR DESCRIPTION
What: Added Bahasa Indonesia language support to MedusaJS by updating language files.
Why: To make MedusaJS more accessible to Indonesian users and expand its global reach.
How: Updated/added .json in the locales directory and tested locally.
Testing: Ran a local test project with npx create-medusa-app@latest and verified Indonesian translations work as expected.